### PR TITLE
feat: implement fragments

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -71,6 +71,13 @@ dependencies {
 
     // Optional - Integration with activities
     implementation 'androidx.activity:activity-compose:1.6.1'
+
+    // Fragments
+    implementation 'androidx.fragment:fragment-ktx:1.5.5'
+    debugImplementation "androidx.fragment:fragment-testing:1.5.5"
+
+    // Navigation drawer
+    implementation 'com.google.android.material:material:1.3.0-alpha03'
 }
 
 tasks.withType(Test) {

--- a/app/src/androidTest/java/com/github/studydistractor/sdp/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/github/studydistractor/sdp/MainActivityTest.kt
@@ -1,0 +1,38 @@
+package com.github.studydistractor.sdp
+
+import android.widget.ImageView
+import androidx.appcompat.app.ActionBarDrawerToggle
+//import androidx.fragment.app.testing.launchFragmentInContainer
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import org.hamcrest.Matchers.containsString
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class MainActivityTest {
+    @get:Rule
+    val rule = ActivityScenarioRule(
+        MainActivity::class.java
+    )
+
+//    @Test fun testImageFragmentContainsImage() {
+//        launchFragmentInContainer<ImageFragment>()
+//        onView(withClassName(
+//            containsString(ImageView::class.simpleName)
+//        )).check(matches(isDisplayed()))
+//    }
+
+    @Test fun testTextFragmentAppearsAtLaunch() {
+        onView(
+            withId(R.id.textFragmentTitle)
+        ).check(matches(isDisplayed()))
+    }
+}

--- a/app/src/main/java/com/github/studydistractor/sdp/ImageFragment.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/ImageFragment.kt
@@ -1,0 +1,7 @@
+package com.github.studydistractor.sdp
+
+import androidx.fragment.app.Fragment
+
+class ImageFragment : Fragment(R.layout.fragment_image) {
+
+}

--- a/app/src/main/java/com/github/studydistractor/sdp/MainActivity.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/MainActivity.kt
@@ -1,13 +1,71 @@
 package com.github.studydistractor.sdp
 
-import androidx.appcompat.app.AppCompatActivity
+import android.media.Image
 import android.os.Bundle
-import androidx.ui.core.Text
-import androidx.ui.core.setContent
+import android.view.MenuItem
+import androidx.appcompat.app.ActionBarDrawerToggle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.drawerlayout.widget.DrawerLayout
+import androidx.fragment.app.add
+import androidx.fragment.app.commit
+import androidx.fragment.app.replace
+import com.google.android.material.navigation.NavigationView
 
-class MainActivity : AppCompatActivity() {
+// Credit: https://www.geeksforgeeks.org/navigation-drawer-in-android/
+class MainActivity : AppCompatActivity(R.layout.activity_main) {
+    lateinit var drawerLayout: DrawerLayout
+    lateinit var actionBarDrawerToggle: ActionBarDrawerToggle
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContent{Text("Hello World !")}
+
+        // Create the drawer
+        drawerLayout = findViewById<DrawerLayout>(R.id.navigation_drawer)
+        actionBarDrawerToggle =
+            ActionBarDrawerToggle(this, drawerLayout, R.string.nav_open, R.string.nav_close)
+
+        // Enable the drawer
+        drawerLayout.addDrawerListener(actionBarDrawerToggle)
+        actionBarDrawerToggle.syncState()
+
+        // Enable action bar hamburger
+        supportActionBar!!.setDisplayHomeAsUpEnabled(true)
+
+        // Add the default fragment
+        if (savedInstanceState == null) {
+            supportFragmentManager.commit {
+                setReorderingAllowed(true)
+                add<TextFragment>(R.id.fragment_container_view)
+            }
+        }
+
+        // Add listeners for the nav drawer
+        val navView = findViewById<NavigationView>(R.id.navigation_view)
+        navView.setNavigationItemSelectedListener {
+            when(it.itemId) {
+                R.id.nav_text -> {
+                    supportFragmentManager.commit {
+                        setReorderingAllowed(true)
+                        replace<TextFragment>(R.id.fragment_container_view)
+                    }
+                    true
+                }
+                R.id.nav_image -> {
+                    supportFragmentManager.commit {
+                        setReorderingAllowed(true)
+                        replace<ImageFragment>(R.id.fragment_container_view)
+                    }
+                    true
+                }
+                else -> false
+            }
+        }
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        // Toggle navigation bar
+        return if (actionBarDrawerToggle.onOptionsItemSelected(item)) {
+            return true
+        } else super.onOptionsItemSelected(item)
     }
 }

--- a/app/src/main/java/com/github/studydistractor/sdp/TextFragment.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/TextFragment.kt
@@ -1,0 +1,7 @@
+package com.github.studydistractor.sdp
+
+import androidx.fragment.app.Fragment
+
+class TextFragment : Fragment(R.layout.fragment_text) {
+
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,18 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.drawerlayout.widget.DrawerLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/navigation_drawer"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".MainActivity">
+    tools:context=".MainActivity"
+    tools:ignore="HardcodedText">
 
-    <TextView
+    <androidx.fragment.app.FragmentContainerView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:id="@+id/fragment_container_view" />
+
+    <!-- this the navigation view which draws and shows the navigation drawer -->
+    <!-- include the menu created in the menu folder -->
+    <com.google.android.material.navigation.NavigationView
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Hello World!"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        android:layout_height="match_parent"
+        android:layout_gravity="start"
+        android:id="@+id/navigation_view"
+        app:menu="@menu/menu" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.drawerlayout.widget.DrawerLayout>

--- a/app/src/main/res/layout/fragment_image.xml
+++ b/app/src/main/res/layout/fragment_image.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/imageFragmentTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="20dp"
+        android:text="Image"
+        android:textAlignment="center"
+        android:textSize="24sp"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <ImageView
+        android:id="@+id/imageView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:background="#FF0000"
+        android:contentDescription="alt"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.498"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/imageFragmentTitle"
+        app:srcCompat="@drawable/ic_launcher_foreground"
+        tools:srcCompat="@drawable/ic_launcher_foreground" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_text.xml
+++ b/app/src/main/res/layout/fragment_text.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/textFragmentTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="20dp"
+        android:text="Texte"
+        android:textAlignment="center"
+        android:textSize="24sp"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/textFragmentText"
+        android:layout_width="wrap_content"
+        android:layout_height="15dp"
+        android:layout_marginTop="40dp"
+        android:text="Lorem ipsum dolor sit amet"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/textFragmentTitle" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/menu/menu.xml
+++ b/app/src/main/res/menu/menu.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:ignore="HardcodedText">
+
+    <item
+        android:id="@+id/nav_text"
+        android:title="Text" />
+
+    <item
+        android:id="@+id/nav_image"
+        android:title="Image" />
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,6 @@
 <resources>
     <string name="app_name">StudyDistractor</string>
+    <string name="textview">TextView</string>
+    <string name="nav_open">Open</string>
+    <string name="nav_close">Close</string>
 </resources>


### PR DESCRIPTION
Implements #4 - a very simple version use of fragments. The result is the UI below.

A hamburger in the action bar toggles the navigation drawer. 
Both items in the navigation drawer menu trigger a fragment swap in the main activity when you click on them. 
The fragments are designed as xml files directly, and not using jetpack compose. 

<img src="https://user-images.githubusercontent.com/26968781/222584741-edebd19a-03a7-45ca-87d0-4430b0f6760c.png" width="300" />

