### PR TITLE
feat : implement #52 notification for random activity

### DIFF
--- a/app/src/androidTest/java/com/github/studydistractor/sdp/RandomProcrastinationActivityActivityTest.kt
+++ b/app/src/androidTest/java/com/github/studydistractor/sdp/RandomProcrastinationActivityActivityTest.kt
@@ -1,0 +1,53 @@
+package com.github.studydistractor.sdp
+
+import android.app.NotificationManager
+import android.content.Context
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@HiltAndroidTest
+class RandomProcrastinationActivityActivityTest {
+
+    @get:Rule(order = 0)
+    var rule = HiltAndroidRule(this)
+
+    @get:Rule(order = 1)
+    val composeRule = createAndroidComposeRule<RandomProcrastinationActivityActivity>()
+
+    @Before
+    fun setup() {
+        rule.inject()
+    }
+
+    @Test
+    fun correctActivityNotificationIsDisplayed() {
+
+        val context: Context = composeRule.activity.applicationContext
+        val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        assertEquals(true, manager.areNotificationsEnabled())
+        composeRule.onNodeWithTag("permission").performClick()
+        composeRule.onNodeWithTag("notification").performClick()
+
+        composeRule.waitUntil { manager.activeNotifications.isNotEmpty() }
+
+        val notification = manager.activeNotifications.first()
+        assertEquals(1, notification.id)
+        assertEquals(RandomActivityNotificationService.RANDOM_ACTIVITY_CHANNEL_ID, notification.notification.channelId)
+
+        manager.activeNotifications.first().notification.contentIntent.send()
+
+        composeRule.onNodeWithText("Test").assertExists()
+        composeRule.onNodeWithText("test description").assertExists()
+    }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,8 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" /> <!-- Apparently necessary for running instrumented tests -->
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
 
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
     <application
         android:name=".StudyDistractorApplication"
         android:allowBackup="true"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,9 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.github.studydistractor.sdp">
 
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-
-    <!-- Apparently necessary for running instrumented tests -->
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" /> <!-- Apparently necessary for running instrumented tests -->
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
 
     <application
@@ -19,10 +17,14 @@
         android:theme="@style/Theme.Material3.Light"
         android:usesCleartextTraffic="true"
         tools:targetApi="31">
+        <activity
+            android:name=".RandomProcrastinationActivityActivity"
+            android:exported="false" />
 
         <meta-data
             android:name="com.google.android.geo.API_KEY"
             android:value="${MAPS_API_KEY}" />
+
         <activity
             android:name=".RegisterActivity"
             android:exported="false" />
@@ -35,10 +37,10 @@
             android:exported="false" />
         <activity
             android:name=".Launcher"
-            android:exported="false"/>
+            android:exported="false" />
         <activity
             android:name=".MainActivity"
-            android:exported="false"/>
+            android:exported="false" />
         <activity
             android:name=".LoginActivity"
             android:exported="true">
@@ -49,4 +51,5 @@
             </intent-filter>
         </activity>
     </application>
+
 </manifest>

--- a/app/src/main/java/com/github/studydistractor/sdp/FireBaseProcrastinationActivityService.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/FireBaseProcrastinationActivityService.kt
@@ -10,28 +10,32 @@ import com.google.firebase.database.FirebaseDatabase
 import com.google.firebase.database.ValueEventListener
 import com.google.firebase.database.ktx.database
 import com.google.firebase.ktx.Firebase
+import javax.inject.Inject
 
-class FireBaseProcrastinationActivityService : ProcrastinationActivityService{
+class FireBaseProcrastinationActivityService @Inject constructor(): ProcrastinationActivityService{
     private val pathStringProcrastinationActivity = "ProcrastinationActivities"
     private val databaseRef : DatabaseReference = FirebaseDatabase.getInstance().getReference(pathStringProcrastinationActivity)
-
     override fun fetchProcrastinationActivities() : SnapshotStateList<ProcrastinationActivity> {
         val result =  mutableStateListOf<ProcrastinationActivity>()
         databaseRef.addListenerForSingleValueEvent(object : ValueEventListener {
-                override fun onDataChange(snapshot: DataSnapshot) {
-                    for(activity in snapshot.children) {
-                        val activityItem = activity.getValue(ProcrastinationActivity::class.java)
-                        if(activityItem != null) {
-                            result.add(activityItem)
-                        }
+            override fun onDataChange(snapshot: DataSnapshot) {
+                for(activity in snapshot.children) {
+                    val activityItem = activity.getValue(ProcrastinationActivity::class.java)
+                    if(activityItem != null) {
+                        result.add(activityItem)
                     }
                 }
+            }
 
-                override fun onCancelled(error: DatabaseError) {
-                    Log.d("Firebase", "loadPost:onCancelled " + error.toException().toString())
-                }
-            })
+            override fun onCancelled(error: DatabaseError) {
+                Log.d("Firebase", "loadPost:onCancelled " + error.toException().toString())
+            }
+        })
 
         return result
+    }
+
+    override fun postProcastinationActivities(activity: ProcrastinationActivity) {
+        databaseRef.child(activity.name!!).setValue(activity)
     }
 }

--- a/app/src/main/java/com/github/studydistractor/sdp/LoginActivity.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/LoginActivity.kt
@@ -49,6 +49,13 @@ class LoginActivity : AppCompatActivity() {
                     .padding(16.dp),
                 horizontalAlignment = Alignment.CenterHorizontally
                     ) {
+                Button(onClick = {
+                    val intent = Intent(this@LoginActivity, RandomProcrastinationActivityActivity::class.java)
+                    startActivity(intent)
+                }) {
+                    Text("Suggest random activity")
+                }
+
                 val email = remember { mutableStateOf(TextFieldValue("")) }
                 val password = remember{mutableStateOf(TextFieldValue("")) }
                 Text(

--- a/app/src/main/java/com/github/studydistractor/sdp/ProcrastinationActivityService.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/ProcrastinationActivityService.kt
@@ -4,4 +4,6 @@ import androidx.compose.runtime.snapshots.SnapshotStateList
 
 interface ProcrastinationActivityService {
     fun fetchProcrastinationActivities() : SnapshotStateList<ProcrastinationActivity>
+
+    fun postProcastinationActivities(activity : ProcrastinationActivity)
 }

--- a/app/src/main/java/com/github/studydistractor/sdp/ProcrastinationActivityServiceModule.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/ProcrastinationActivityServiceModule.kt
@@ -1,0 +1,18 @@
+package com.github.studydistractor.sdp
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object ProcrastinationActivityServiceModule {
+
+    @Singleton
+    @Provides
+    fun provideProcrastinationAcitvityService() : ProcrastinationActivityService {
+        return FireBaseProcrastinationActivityService()
+    }
+}

--- a/app/src/main/java/com/github/studydistractor/sdp/RandomActivityNotificationService.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/RandomActivityNotificationService.kt
@@ -1,0 +1,54 @@
+package com.github.studydistractor.sdp
+
+import android.Manifest
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import android.util.Log
+import androidx.core.app.ActivityCompat
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+
+/**
+ * This class represent the notification service that shows random activities notification
+ */
+class RandomActivityNotificationService(
+    private val context : Context
+) {
+    private val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE)
+            as NotificationManager
+
+    /**
+     * Display notification, if the user click on the notification, it will display the activity
+     * @param activity activity to be displayed
+     */
+    fun showNotification(activity: ProcrastinationActivity) {
+        val activityIntent = Intent(context, ProcrastinationActivityActivity::class.java)
+            .apply {
+                putExtra("activity", activity)
+            }
+
+        val activityPendingIntent = PendingIntent.getActivity(
+            context,
+            1,
+            activityIntent,
+            PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val notification = NotificationCompat.Builder(context, RANDOM_ACTIVITY_CHANNEL_ID)
+            .setSmallIcon(R.drawable.magic_button)
+            .setContentTitle("Procrastination activity")
+            .setContentText("${activity.name} : ${activity.description}")
+            .setContentIntent(activityPendingIntent)
+            .build()
+
+        notificationManager.notify(1, notification)
+    }
+
+    companion object {
+        const val RANDOM_ACTIVITY_CHANNEL_ID = "random_activity_channel"
+    }
+}

--- a/app/src/main/java/com/github/studydistractor/sdp/RandomProcrastinationActivityActivity.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/RandomProcrastinationActivityActivity.kt
@@ -1,0 +1,40 @@
+package com.github.studydistractor.sdp
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.os.Build
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import androidx.activity.compose.setContent
+import androidx.compose.runtime.Composable
+
+class RandomProcrastinationActivityActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        createNotification()
+        setContent {
+            DisplayRandomActivity()
+        }
+    }
+
+    @Composable
+    fun DisplayRandomActivity() {
+
+    }
+
+    fun createNotification() {
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val name = "test channel"
+            val descriptionText = "test description"
+            val importance = NotificationManager.IMPORTANCE_DEFAULT
+            val channel = NotificationChannel("TEST_ID", name, importance).apply {
+                description = descriptionText
+            }
+            // Register the channel with the system
+            val notificationManager: NotificationManager =
+                getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            notificationManager.createNotificationChannel(channel)
+        }
+    }
+}

--- a/app/src/main/java/com/github/studydistractor/sdp/RandomProcrastinationActivityActivity.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/RandomProcrastinationActivityActivity.kt
@@ -5,6 +5,7 @@ import android.content.pm.PackageManager
 import android.os.Build
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
@@ -13,38 +14,52 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.Button
 import androidx.compose.material.Text
 import androidx.compose.runtime.*
+import androidx.compose.runtime.snapshots.Snapshot
+import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.core.content.ContextCompat
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onEach
+import javax.inject.Inject
 
 /**
  * Activity that has a button to request a random activity
  */
-class RandomProcrastinationActivityActivity : AppCompatActivity() {
+@AndroidEntryPoint(AppCompatActivity::class)
+class RandomProcrastinationActivityActivity : Hilt_RandomProcrastinationActivityActivity() {
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val service = RandomActivityNotificationService(applicationContext)
+        val notificationService = RandomActivityNotificationService(applicationContext)
         setContent {
-
-            DisplayRandomActivity(service)
-        }
+            DisplayRandomActivity(notificationService)
         }
     }
 
+    /**
+     * This function will handle 2 buttons, the first one to ask permission for notification and
+     * the second one will display a notification.
+     *
+     * @Param service, the notification service that will post
+     */
     @Composable
     fun DisplayRandomActivity(service: RandomActivityNotificationService) {
         val currentActivity = ProcrastinationActivity("Test", "test description")
 
         val context = LocalContext.current
         var hasNotificationPermission by remember {
-            if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                 mutableStateOf(
                     ContextCompat.checkSelfPermission(
                         context,
                         Manifest.permission.POST_NOTIFICATIONS
                     ) == PackageManager.PERMISSION_DENIED
                 )
-            }  else mutableStateOf(true)
+            } else mutableStateOf(true)
         }
 
         val permissionLauncher = rememberLauncherForActivityResult(
@@ -56,19 +71,27 @@ class RandomProcrastinationActivityActivity : AppCompatActivity() {
 
         Column(modifier = Modifier.fillMaxSize()) {
 
-            Button(onClick = {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                    permissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
-                }
-            }) {
+            Button(
+                onClick = {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                        permissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+                    }
+                },
+                modifier = Modifier.testTag("permission")
+            ) {
                 Text("Request permission")
             }
-            Button(onClick = {
-                if(hasNotificationPermission) {
-                    service.showNotification(currentActivity)
-                }
-            }) {
+
+            Button(
+                onClick = {
+                    if (hasNotificationPermission) {
+                        service.showNotification(currentActivity)
+                    }
+                },
+                modifier = Modifier.testTag("notification")
+                ) {
                 Text("Show me notification")
             }
         }
     }
+}

--- a/app/src/main/java/com/github/studydistractor/sdp/RandomProcrastinationActivityActivity.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/RandomProcrastinationActivityActivity.kt
@@ -1,40 +1,74 @@
 package com.github.studydistractor.sdp
 
-import android.app.NotificationChannel
-import android.app.NotificationManager
-import android.content.Context
+import android.Manifest
+import android.content.pm.PackageManager
 import android.os.Build
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
-import androidx.compose.runtime.Composable
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.ContextCompat
 
+/**
+ * Activity that has a button to request a random activity
+ */
 class RandomProcrastinationActivityActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        createNotification()
+        val service = RandomActivityNotificationService(applicationContext)
         setContent {
-            DisplayRandomActivity()
+
+            DisplayRandomActivity(service)
+        }
         }
     }
 
     @Composable
-    fun DisplayRandomActivity() {
+    fun DisplayRandomActivity(service: RandomActivityNotificationService) {
+        val currentActivity = ProcrastinationActivity("Test", "test description")
 
-    }
+        val context = LocalContext.current
+        var hasNotificationPermission by remember {
+            if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                mutableStateOf(
+                    ContextCompat.checkSelfPermission(
+                        context,
+                        Manifest.permission.POST_NOTIFICATIONS
+                    ) == PackageManager.PERMISSION_DENIED
+                )
+            }  else mutableStateOf(true)
+        }
 
-    fun createNotification() {
-        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val name = "test channel"
-            val descriptionText = "test description"
-            val importance = NotificationManager.IMPORTANCE_DEFAULT
-            val channel = NotificationChannel("TEST_ID", name, importance).apply {
-                description = descriptionText
+        val permissionLauncher = rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.RequestPermission(),
+            onResult = { isGranted ->
+                hasNotificationPermission = isGranted
             }
-            // Register the channel with the system
-            val notificationManager: NotificationManager =
-                getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-            notificationManager.createNotificationChannel(channel)
+        )
+
+        Column(modifier = Modifier.fillMaxSize()) {
+
+            Button(onClick = {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    permissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+                }
+            }) {
+                Text("Request permission")
+            }
+            Button(onClick = {
+                if(hasNotificationPermission) {
+                    service.showNotification(currentActivity)
+                }
+            }) {
+                Text("Show me notification")
+            }
         }
     }
-}

--- a/app/src/main/java/com/github/studydistractor/sdp/StudyDistractorApplication.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/StudyDistractorApplication.kt
@@ -1,9 +1,36 @@
 package com.github.studydistractor.sdp
 
 import android.app.Application
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.os.Build
 import dagger.hilt.android.HiltAndroidApp
 
 @HiltAndroidApp
 class StudyDistractorApplication : Application(){
+    override fun onCreate() {
+        super.onCreate()
+        createNotificationChannel()
+    }
 
+    /**
+     * Create the channel to display notification
+     */
+    private fun createNotificationChannel() {
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val name = "Procrastination activity"
+            val descriptionText = "Used to display notifications about procrastination activities"
+            val channel = NotificationChannel(
+                RandomActivityNotificationService.RANDOM_ACTIVITY_CHANNEL_ID,
+                name,
+                NotificationManager.IMPORTANCE_DEFAULT
+            ).apply {
+                description = descriptionText
+            }
+            // Register the channel with the system
+            val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            notificationManager.createNotificationChannel(channel)
+        }
+    }
 }

--- a/app/src/main/res/layout/activity_random_procrastination_activity.xml
+++ b/app/src/main/res/layout/activity_random_procrastination_activity.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".RandomProcrastinationActivityActivity">
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
#52 is partially implemented. 

There is a new activity where the user can trigger the notification and also give permission to the app to send notification. 
If the user click on the notification, it will display the procrastination activity in the app. 

I had struggles with fetching data from the firebase and it is taking too long to be able to solve this problem.
I suggest a new task for the next sprint that will handle the fetching. Other than that, there is one test with end to end testing. 
