### PR TITLE
feat(#90): refactor registration to implement TA feedback

### DIFF
--- a/app/src/androidTest/java/com/github/studydistractor/sdp/login/FakeLoginModule.kt
+++ b/app/src/androidTest/java/com/github/studydistractor/sdp/login/FakeLoginModule.kt
@@ -1,6 +1,5 @@
 package com.github.studydistractor.sdp.login
 
-import android.util.Log
 import com.google.android.gms.tasks.Task
 import com.google.android.gms.tasks.TaskCompletionSource
 import com.google.firebase.auth.AuthResult
@@ -8,7 +7,6 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.components.ActivityComponent
-import dagger.hilt.testing.TestInstallIn
 import javax.inject.Inject
 
 @Module
@@ -23,12 +21,16 @@ object FakeLoginModule {
 
 class FakeLoginAuth @Inject constructor() : LoginAuthInterface {
     override fun loginWithEmail(email: String, password: String): Task<AuthResult> {
-        var t = TaskCompletionSource<AuthResult>()
-        if(email == "email" && password == "password"){
+        val t = TaskCompletionSource<AuthResult>()
+        return if(email == "invalidEmail" && password == "invalidPassword"){
             t.setException(IllegalArgumentException())
-            return t.task
+            t.task
+        } else if (email == "validEmail" && password == "validPassword"){
+            t.setResult(null)
+            t.task
+        } else {
+            t.setException(IllegalArgumentException())
+            t.task
         }
-        t.setResult(null)
-        return t.task
     }
 }

--- a/app/src/androidTest/java/com/github/studydistractor/sdp/ui/LoginScreenTest.kt
+++ b/app/src/androidTest/java/com/github/studydistractor/sdp/ui/LoginScreenTest.kt
@@ -12,8 +12,8 @@ import org.junit.Assert.assertEquals
 
 @HiltAndroidTest
 class LoginScreenTest {
-    var registerButtonClicks = 0
-    var loggedInCount = 0
+    private var registerButtonClicks = 0
+    private var loggedInCount = 0
 
     @get:Rule(order = 0)
     var rule = HiltAndroidRule(this)
@@ -38,15 +38,18 @@ class LoginScreenTest {
 
     @Test
     fun testToLoginWithValidEmailAndPassword() {
-        var email = "test@gmail.com"
-        var password = "1234567890"
+        val email = "validEmail"
+        val password = "validPassword"
         composeRule.onNodeWithTag("email").performTextInput(email)
         composeRule.onNodeWithTag("password").performTextInput(password)
 
         assertEquals(0, loggedInCount)
         composeRule.onNodeWithTag("login").performClick()
-        composeRule.waitUntil(1000) {
-            loggedInCount == 1
+        try {
+            composeRule.waitUntil(1000) {
+                loggedInCount == 1
+            }
+        } catch (_: ComposeTimeoutException) {
         }
 
         assertEquals(0, registerButtonClicks)
@@ -67,37 +70,79 @@ class LoginScreenTest {
 
     @Test
     fun testToLoginWithInvalidEmailAndPassword() {
-        var email = "email"
-        var password = "password"
+        val email = "invalidEmail"
+        val password = "invalidPassword"
         composeRule.onNodeWithTag("email").performTextInput(email)
         composeRule.onNodeWithTag("password").performTextInput(password)
         composeRule.onNodeWithTag("login").performClick()
-
+        try {
+            composeRule.waitUntil(1000) {
+                loggedInCount == 1
+            }
+        } catch (_: ComposeTimeoutException) {
+        }
         assertEquals(0, registerButtonClicks)
         assertEquals(0, loggedInCount)
     }
 
     @Test
     fun testToLoginWithoutEmail() {
-        var password = "1234567890"
+        val password = "validPassword"
         composeRule.onNodeWithTag("password").performTextInput(password)
         composeRule.onNodeWithTag("login").performClick()
-
+        try {
+            composeRule.waitUntil(1000) {
+                loggedInCount == 1
+            }
+        } catch (_: ComposeTimeoutException) {
+        }
         assertEquals(0, registerButtonClicks)
         assertEquals(0, loggedInCount)
     }
 
     @Test
     fun testToLoginWithoutPassword() {
-        var email = "test@gmail.com"
+        val email = "validEmail"
         composeRule.onNodeWithTag("email").performTextInput(email)
         composeRule.onNodeWithTag("login").performClick()
-
+        try {
+            composeRule.waitUntil(1000) {
+                loggedInCount == 1
+            }
+        } catch (_: ComposeTimeoutException) {
+        }
         assertEquals(0, registerButtonClicks)
         assertEquals(0, loggedInCount)
     }
     @Test
     fun testRegisterButton(){
         composeRule.onNodeWithTag("register").performClick()
+        try {
+            composeRule.waitUntil(1000) {
+                registerButtonClicks == 1
+            }
+        } catch (_: ComposeTimeoutException) {
+        }
+        assertEquals(1, registerButtonClicks)
     }
+
+    @Test
+    fun testLogInWithValidEmailAndPasswordWithWhiteSpace(){
+        val email = "validEmail   "
+        val password = "validPassword   "
+        composeRule.onNodeWithTag("email").performTextInput(email)
+        composeRule.onNodeWithTag("password").performTextInput(password)
+
+        assertEquals(0, loggedInCount)
+        composeRule.onNodeWithTag("login").performClick()
+        try {
+            composeRule.waitUntil(1000) {
+                loggedInCount == 1
+            }
+        } catch (_: ComposeTimeoutException) {
+        }
+
+        assertEquals(0, registerButtonClicks)
+        assertEquals(1, loggedInCount)
+}
 }

--- a/app/src/androidTest/java/com/github/studydistractor/sdp/ui/RegisterScreenTest.kt
+++ b/app/src/androidTest/java/com/github/studydistractor/sdp/ui/RegisterScreenTest.kt
@@ -5,14 +5,14 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import com.github.studydistractor.sdp.register.FakeRegisterAuthModule.provideFakeRegisterAuth
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.Assert.assertEquals
 
 @HiltAndroidTest
 class RegisterScreenTest {
-    var clicks = 0
+    private var successfullyRegistered = false
 
     @get:Rule(order = 0)
     var rule = HiltAndroidRule(this)
@@ -24,10 +24,10 @@ class RegisterScreenTest {
     fun setup() {
         rule.inject()
 
-        clicks = 0
+        successfullyRegistered = false
         composeTestRule.setContent {
             RegisterScreen(
-                onRegistered = { clicks++ },
+                onRegistered = { successfullyRegistered = true },
                 registerAuth = provideFakeRegisterAuth()
             )
         }
@@ -38,65 +38,119 @@ class RegisterScreenTest {
     fun testRegisteredButtonFailsWithNoData() {
         composeTestRule.onNodeWithTag("register-screen__registered-button").assertIsDisplayed()
         composeTestRule.onNodeWithTag("register-screen__registered-button").assertHasClickAction()
-        assertEquals(0, clicks)
+        assertEquals(false, successfullyRegistered)
         composeTestRule.onNodeWithTag("register-screen__registered-button").performClick()
-        assertEquals(0, clicks)
+        try {
+            composeTestRule.waitUntil(1000) {
+                successfullyRegistered
+            }
+        } catch (_: ComposeTimeoutException) {
+        }
+        assertEquals(false, successfullyRegistered)
     }
     @Test
     fun testRegisterButton() {
 
-        val email = "test@gmail.com"
-        val password = "123456789qwertzuiop"
+        val email = "test123@gmail.com"
+        val password = "patate123"
         // Find the email and password text fields and enter some text
         composeTestRule.onNodeWithTag("email").performTextInput(email)
         composeTestRule.onNodeWithTag("password").performTextInput(password)
         composeTestRule.onNodeWithTag("pseudo").performTextInput("test")
 
         // Find the "Register" button and click it
-
+        assertEquals(false, successfullyRegistered)
         composeTestRule.onNodeWithTag("register-screen__registered-button").performClick()
+        try {
+            composeTestRule.waitUntil(1000) {
+                successfullyRegistered
+            }
+        } catch (_: ComposeTimeoutException) {
+        }
+        assertEquals(true, successfullyRegistered)
     }
     @Test
     fun testRegisterButtonWithoutPassword() {
 
         val email = "test@gmail.com"
-        val password = "123456789qwertzuiop"
-        val pseudo = "test"
         // Find the email and password text fields and enter some text
         composeTestRule.onNodeWithTag("email").performTextInput(email)
 //        composeTestRule.onNodeWithTag("password").performTextInput(password)
         composeTestRule.onNodeWithTag("pseudo").performTextInput("test")
 
         // Find the "Register" button and click it
-
+        assertEquals(false, successfullyRegistered)
         composeTestRule.onNodeWithTag("register-screen__registered-button").performClick()
+        try {
+            composeTestRule.waitUntil(1000) {
+                successfullyRegistered
+            }
+        } catch (_: ComposeTimeoutException) {
+        }
+        assertEquals(false, successfullyRegistered)
     }
     @Test
     fun testRegisterButtonWithoutEmail() {
 
-        val email = "test@gmail.com"
         val password = "123456789qwertzuiop"
-        val pseudo = "test"
         // Find the email and password text fields and enter some text
         composeTestRule.onNodeWithTag("password").performTextInput(password)
         composeTestRule.onNodeWithTag("pseudo").performTextInput("test")
 
         // Find the "Register" button and click it
+        assertEquals(false, successfullyRegistered)
 
         composeTestRule.onNodeWithTag("register-screen__registered-button").performClick()
+        try {
+            composeTestRule.waitUntil(1000) {
+                successfullyRegistered
+            }
+        } catch (_: ComposeTimeoutException) {
+        }
+        assertEquals(false, successfullyRegistered)
     }
     @Test
     fun testRegisterButtonWithoutPseudo() {
 
         val email = "test@gmail.com"
         val password = "123456789qwertzuiop"
-        val pseudo = "test"
         // Find the email and password text fields and enter some text
         composeTestRule.onNodeWithTag("email").performTextInput(email)
         composeTestRule.onNodeWithTag("password").performTextInput(password)
 
         // Find the "Register" button and click it
-
+        assertEquals(false, successfullyRegistered)
         composeTestRule.onNodeWithTag("register-screen__registered-button").performClick()
+        try {
+            composeTestRule.waitUntil(1000) {
+                successfullyRegistered
+            }
+        } catch (_: ComposeTimeoutException) {
+        }
+        assertEquals(false, successfullyRegistered)
+//        check if toast appears
+
+
+    }
+
+    @Test
+    fun testRegistrationWithShortPassword() {
+        val email = "test@gmail.com"
+        val password = "a"
+        // Find the email and password text fields and enter some text
+        composeTestRule.onNodeWithTag("email").performTextInput(email)
+        composeTestRule.onNodeWithTag("password").performTextInput(password)
+        composeTestRule.onNodeWithTag("pseudo").performTextInput("test")
+
+        // Find the "Register" button and click it
+        assertEquals(false, successfullyRegistered)
+        composeTestRule.onNodeWithTag("register-screen__registered-button").performClick()
+        try {
+            composeTestRule.waitUntil(1000) {
+                successfullyRegistered
+            }
+        } catch (_: ComposeTimeoutException) {
+        }
+        assertEquals(false, successfullyRegistered)
     }
 }

--- a/app/src/main/java/com/github/studydistractor/sdp/register/Register.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/register/Register.kt
@@ -1,8 +1,5 @@
 package com.github.studydistractor.sdp.register
 
-import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.setValue
-
 class Register {
     companion object {
         fun newUser(auth : RegisterAuthInterface, email: String, password: String, pseudo: String, onRegisterSuccess: () -> Unit, onRegisterFailure: (reason: String) -> Unit) {
@@ -12,8 +9,9 @@ class Register {
                 onRegisterFailure("Password is empty")
             } else if ( pseudo.isEmpty()) {
                 onRegisterFailure("Pseudo is empty")
+            } else if (password.length < 6) {
+                onRegisterFailure("Password must be at least 6 characters")
             } else {
-
                 auth.createUserWithEmailAndPassword(email.trim(), password.trim())
                     .addOnCompleteListener { task ->
                         if (task.isSuccessful) {

--- a/app/src/main/java/com/github/studydistractor/sdp/ui/LoginScreen.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/ui/LoginScreen.kt
@@ -85,8 +85,8 @@ fun LoginScreen(
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        var emailstr = email.value.text
-        var passwordstr = password.value.text
+        var emailstr = email.value.text.trim()
+        var passwordstr = password.value.text.trim()
         Button(
             onClick = {
                 if (TextUtils.isEmpty(emailstr) || TextUtils.isEmpty(passwordstr)) {


### PR DESCRIPTION
Closes #90 and #94, i.e. now the user receives an informative message if their password is too short when trying to register. Minor improvement: whitespace is now trimmed from user input during login.