### PR TITLE
feat(#132): create the create events screen 

### DIFF
--- a/app/src/androidTest/java/com/github/studydistractor/sdp/fakeServices/CreateEventServiceFake.kt
+++ b/app/src/androidTest/java/com/github/studydistractor/sdp/fakeServices/CreateEventServiceFake.kt
@@ -1,0 +1,11 @@
+package com.github.studydistractor.sdp.fakeServices
+
+import com.github.studydistractor.sdp.createEvent.CreateEventModel
+import com.google.android.gms.tasks.Task
+import com.google.android.gms.tasks.Tasks
+
+class CreateEventServiceFake : CreateEventModel {
+    override fun createEvent(eventInformation: Map<String, Any?>): Task<Void> {
+        return Tasks.whenAll(setOf(Tasks.forResult("")))
+    }
+}

--- a/app/src/androidTest/java/com/github/studydistractor/sdp/fakeServices/EventHistoryServiceFake.kt
+++ b/app/src/androidTest/java/com/github/studydistractor/sdp/fakeServices/EventHistoryServiceFake.kt
@@ -1,0 +1,119 @@
+package com.github.studydistractor.sdp.fakeServices
+
+import com.github.studydistractor.sdp.data.Event
+import com.github.studydistractor.sdp.data.EventParticipants
+import com.github.studydistractor.sdp.eventHistory.EventHistoryModel
+import com.google.android.gms.tasks.Task
+import com.google.android.gms.tasks.Tasks
+
+class EventHistoryServiceFake: EventHistoryModel {
+    private fun getEvents(): Task<List<Event>> {
+        return Tasks.forResult(
+            listOf(
+                Event(
+                    "event1",
+                    "event1",
+                    "event1",
+                    1.0,
+                    1.0,
+                    "10-10-1997 00:00",
+                    "11-11-1997 00:00",
+                    false,
+                    0,
+                    "chatId1"
+                ),
+                Event(
+                    "event2",
+                    "event2",
+                    "event2",
+                    2.0,
+                    2.0,
+                    "10-10-1998 00:00",
+                    "11-11-1998 00:00",
+                    false,
+                    0,
+                    "chatId2"
+                ),
+                Event(
+                    "event3",
+                    "event3",
+                    "event3",
+                    3.0,
+                    3.0,
+                    "10-10-1999 00:00",
+                    "11-11-1999 00:00",
+                    false,
+                    0,
+                    "chatId3"
+                ),
+                Event(
+                    "NotFinishedEvent",
+                    "NotFinishedEvent",
+                    "NotFinishedEvent",
+                    3.0,
+                    3.0,
+                    "10-10-1999 00:00",
+                    "10-10-2050 00:00",
+                    false,
+                    0,
+                    "NotFinishedEvent"
+                ),
+                Event(
+                    "UserHasNotTakenPartIn",
+                    "UserHasNotTakenPartIn",
+                    "UserHasNotTakenPartIn",
+                    3.0,
+                    3.0,
+                    "10-10-1999 00:00",
+                    "10-10-2000 00:00",
+                    false,
+                    0,
+                    "UserHasNotTakenPartIn"
+                )
+            )
+        )
+    }
+
+    private fun getEventParticipants(): Task<List<EventParticipants>> {
+        return Tasks.forResult(
+            listOf(
+                EventParticipants(
+                    "event1",
+                    listOf("userId", "Joe", "Billy")
+                ),
+                EventParticipants(
+                    "event2",
+                    listOf("userId", "Joe", "Max", "Billy")
+                ),
+                EventParticipants(
+                    "event3",
+                    listOf("userId", "Daniel")
+                ),
+                EventParticipants(
+                    "NotFinishedEvent",
+                    listOf("userId", "Kevin", "Nelson")
+                ),
+                EventParticipants(
+                    "UserHasNotTakenPartIn",
+                    listOf("Athena", "Adrien", "Yohan", "Willy", "Orélian")
+                )
+            )
+        )
+    }
+
+    override fun observeEvents(onEventChange: (List<Event>) -> Unit) {
+        getEvents().continueWith {
+            t -> onEventChange(t.result)
+        }
+    }
+
+    override fun observeEventsParticipants(onEventParticipantsChange: (List<EventParticipants>) -> Unit) {
+        getEventParticipants().continueWith {
+                t -> onEventParticipantsChange(t.result)
+        }
+    }
+
+    override fun getCurrentUid(): Task<String> {
+        return Tasks.forResult("userId")
+    }
+}

--- a/app/src/androidTest/java/com/github/studydistractor/sdp/ui/AppBarTopTest.kt
+++ b/app/src/androidTest/java/com/github/studydistractor/sdp/ui/AppBarTopTest.kt
@@ -28,7 +28,9 @@ class AppBarTopTest {
                 navigateUp = { throw Error("this should never be called") },
                 goToMapActivity = { /* this must not be tested as it is temporary */ },
                 goToHistoryActivity = { /* this must not be tested as it is temporary */ },
-                goToCreateDistractionActivity = { /* this must not be tested as it is temporary */ })
+                goToCreateDistractionActivity = { /* this must not be tested as it is temporary */ },
+                goToCreateEventActivity = { /* this must not be tested as it is temporary */ }
+                )
         }
 
         composeRule.onNodeWithTag("app-bar-top__title").assertIsDisplayed()
@@ -43,7 +45,9 @@ class AppBarTopTest {
                 navigateUp = { throw Error("this should never be called") },
                 goToMapActivity = { /* this must not be tested as it is temporary */ },
                 goToHistoryActivity = { /* this must not be tested as it is temporary */ },
-                goToCreateDistractionActivity = { /* this must not be tested as it is temporary */ })
+                goToCreateDistractionActivity = { /* this must not be tested as it is temporary */ },
+                goToCreateEventActivity = { /* this must not be tested as it is temporary */ }
+            )
         }
 
         composeRule.onNodeWithTag("app-bar-top__back-button").assertDoesNotExist()
@@ -60,7 +64,9 @@ class AppBarTopTest {
                 navigateUp = { backClicks++ },
                 goToMapActivity = { /* this must not be tested as it is temporary */ },
                 goToHistoryActivity = { /* this must not be tested as it is temporary */ },
-                goToCreateDistractionActivity = { /* this must not be tested as it is temporary */ })
+                goToCreateDistractionActivity = { /* this must not be tested as it is temporary */ },
+                goToCreateEventActivity = { /* this must not be tested as it is temporary */ }
+            )
         }
 
         composeRule.onNodeWithTag("app-bar-top__back-button").assertIsDisplayed()

--- a/app/src/androidTest/java/com/github/studydistractor/sdp/ui/CreateDistractionScreenTest.kt
+++ b/app/src/androidTest/java/com/github/studydistractor/sdp/ui/CreateDistractionScreenTest.kt
@@ -5,6 +5,8 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertIsOn
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -38,7 +40,7 @@ class CreateDistractionScreenTest {
 
     @Test
     fun testScreenIsShown() {
-        composeRule.onNodeWithTag("create-distraction-screen__main-container").assertIsDisplayed()
+        composeRule.onNodeWithTag("create-activity-screen__main-container").assertIsDisplayed()
         composeRule.onNodeWithText("Create new distraction").assertIsDisplayed()
     }
 
@@ -63,12 +65,13 @@ class CreateDistractionScreenTest {
     @OptIn(ExperimentalComposeUiApi::class, ExperimentalTestApi::class)
     @Test
     fun supportingTextDisplaysCorrectlyWhenEmpty() {
-        composeRule.onNodeWithTag("name").performTextInput("test")
-        composeRule.onNodeWithTag("description").performTextInput("test")
-        composeRule.onNodeWithTag("name").assert(hasText("test"))
-        composeRule.onNodeWithTag("description").assert(hasText("test"))
-        composeRule.onNodeWithTag("nameSupport", useUnmergedTree = true).assert(hasText("4/20"))
-        composeRule.onNodeWithTag("descriptionSupport", useUnmergedTree = true).assert(hasText("4/200"))
+        composeRule.onNodeWithTag("name").performTextInput("test name")
+        composeRule.onNodeWithTag("description").performTextInput("")
+        composeRule.onNodeWithTag("description").performTextInput("test description")
+        composeRule.onNodeWithTag("name").assert(hasText("test name"))
+        composeRule.onNodeWithTag("description").assert(hasText("test description"))
+        composeRule.onNodeWithTag("nameSupport", useUnmergedTree = true).assert(hasText("9/20"))
+        composeRule.onNodeWithTag("descriptionSupport", useUnmergedTree = true).assert(hasText("16/200"))
     }
 
     @Test
@@ -81,5 +84,138 @@ class CreateDistractionScreenTest {
         composeRule.onNodeWithTag("name").assert(hasText("${name.length}/20"))
         composeRule.onNodeWithTag("description").assert(hasText(description))
         composeRule.onNodeWithTag("description").assert(hasText("${description.length}/200"))
+    }
+
+    @Test
+    fun titleDisplaysCorrectly() {
+        composeRule.onNodeWithTag("create-distraction-screen__title").assert(hasText("Create distraction"))
+    }
+
+    @Test
+    fun checkBoxIsDisplayed() {
+        composeRule.onNodeWithTag("checkbox").assertExists()
+    }
+
+    @Test
+    fun locationRowIsDisplayed() {
+        composeRule.onNodeWithTag("locationRow").assertExists()
+    }
+
+    @Test
+    fun checkBoxIsNotCheckedByDefault() {
+        composeRule.onNodeWithTag("checkbox").assertIsOff()
+    }
+
+    @Test
+    fun checkBoxIsCheckedWhenClicked() {
+        composeRule.onNodeWithTag("checkbox").assertIsOff()
+        composeRule.onNodeWithTag("checkbox").performClick()
+        composeRule.onNodeWithTag("checkbox").assertIsOn()
+    }
+
+    @Test
+    fun checkBoxIsNotCheckedWhenClickedTwice() {
+        composeRule.onNodeWithTag("checkbox").assertIsOff()
+        composeRule.onNodeWithTag("checkbox").performClick()
+        composeRule.onNodeWithTag("checkbox").assertIsOn()
+        composeRule.onNodeWithTag("checkbox").performClick()
+        composeRule.onNodeWithTag("checkbox").assertIsOff()
+    }
+
+    @Test
+    fun latitudeAndLongitudeAreDisplayedWhenCheckBoxIsChecked() {
+        composeRule.onNodeWithTag("checkbox").performClick()
+        composeRule.onNodeWithTag("latitude").assertExists()
+        composeRule.onNodeWithTag("longitude").assertExists()
+    }
+
+    @Test
+    fun latitudeAndLongitudeAreNotDisplayedWhenCheckBoxIsNotChecked() {
+        composeRule.onNodeWithTag("latitude").assertDoesNotExist()
+        composeRule.onNodeWithTag("longitude").assertDoesNotExist()
+    }
+
+    @Test
+    fun latitudeAndLongitudeAreNotDisplayedWhenCheckBoxIsCheckedAndUnchecked() {
+        composeRule.onNodeWithTag("checkbox").performClick()
+        composeRule.onNodeWithTag("latitude").assertExists()
+        composeRule.onNodeWithTag("longitude").assertExists()
+        composeRule.onNodeWithTag("checkbox").performClick()
+        composeRule.onNodeWithTag("latitude").assertDoesNotExist()
+        composeRule.onNodeWithTag("longitude").assertDoesNotExist()
+    }
+
+    @Test
+    fun activityWithInvalidLatitudeIsNotInserted() {
+        successCount = 0
+        val name = "test"
+        val description = "test description"
+        composeRule.onNodeWithTag("name").performTextInput(name)
+        composeRule.onNodeWithTag("description").performTextInput(description)
+        composeRule.onNodeWithTag("checkbox").performClick()
+        composeRule.onNodeWithTag("latitude").performTextInput("91")
+        composeRule.onNodeWithTag("longitude").performTextInput("0")
+        composeRule.onNodeWithTag("addActivity").performClick()
+        Thread.sleep(500)
+        assertEquals(0, successCount)
+    }
+
+    @Test
+    fun activityWithInvalidLongitudeIsNotInserted() {
+        successCount = 0
+        val name = "test"
+        val description = "test description"
+        composeRule.onNodeWithTag("name").performTextInput(name)
+        composeRule.onNodeWithTag("description").performTextInput(description)
+        composeRule.onNodeWithTag("checkbox").performClick()
+        composeRule.onNodeWithTag("latitude").performTextInput("0")
+        composeRule.onNodeWithTag("longitude").performTextInput("181")
+        composeRule.onNodeWithTag("addActivity").performClick()
+        Thread.sleep(500)
+        assertEquals(0, successCount)
+    }
+
+    @Test
+    fun activityWithValidLatitudeAndLongitudeIsInserted() {
+        successCount = 0
+        val name = "test"
+        val description = "test description"
+        composeRule.onNodeWithTag("name").performTextInput(name)
+        composeRule.onNodeWithTag("description").performTextInput(description)
+        composeRule.onNodeWithTag("checkbox").performClick()
+        composeRule.onNodeWithTag("latitude").performTextInput("0")
+        composeRule.onNodeWithTag("longitude").performTextInput("0")
+        composeRule.onNodeWithTag("addActivity").performClick()
+        Thread.sleep(500)
+        assertEquals(1, successCount)
+    }
+
+
+    @Test
+    fun activityWithOnlyLatitudeIsNotInserted() {
+        successCount = 0
+        val name = "test"
+        val description = "test description"
+        composeRule.onNodeWithTag("name").performTextInput(name)
+        composeRule.onNodeWithTag("description").performTextInput(description)
+        composeRule.onNodeWithTag("checkbox").performClick()
+        composeRule.onNodeWithTag("latitude").performTextInput("0")
+        composeRule.onNodeWithTag("addActivity").performClick()
+        Thread.sleep(500)
+        assertEquals(0, successCount)
+    }
+
+    @Test
+    fun activityWithOnlyLongitudeIsNotInserted() {
+        successCount = 0
+        val name = "test"
+        val description = "test description"
+        composeRule.onNodeWithTag("name").performTextInput(name)
+        composeRule.onNodeWithTag("description").performTextInput(description)
+        composeRule.onNodeWithTag("checkbox").performClick()
+        composeRule.onNodeWithTag("longitude").performTextInput("0")
+        composeRule.onNodeWithTag("addActivity").performClick()
+        Thread.sleep(500)
+        assertEquals(0, successCount)
     }
 }

--- a/app/src/androidTest/java/com/github/studydistractor/sdp/ui/CreateEventScreenTest.kt
+++ b/app/src/androidTest/java/com/github/studydistractor/sdp/ui/CreateEventScreenTest.kt
@@ -1,0 +1,538 @@
+package com.github.studydistractor.sdp.ui
+
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotSelected
+import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performTextInput
+import com.github.studydistractor.sdp.createDistraction.CreateDistractionViewModel
+import com.github.studydistractor.sdp.createEvent.CreateEventModel
+import com.github.studydistractor.sdp.createEvent.CreateEventViewModel
+import com.github.studydistractor.sdp.fakeServices.CreateDistractionServiceFake
+import com.github.studydistractor.sdp.fakeServices.CreateEventServiceFake
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class CreateEventScreenTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private val createEventServiceFake = CreateEventServiceFake()
+    private val viewModel = CreateEventViewModel(createEventServiceFake)
+    private var successCount = 0
+
+    @Before
+    fun setup() {
+        successCount = 0
+        composeRule.setContent {
+            CreateEventScreen(
+                createEventViewModel = viewModel,
+                onEventCreated = { successCount++ })
+        }
+    }
+
+    @Test
+    fun mainContainerExists() {
+        composeRule.onNodeWithTag("create-activity-screen__main-container").assertExists()
+    }
+
+    @Test
+    fun titleExistsAndIsDisplayedCorrectly() {
+        composeRule.onNodeWithTag("create-event-screen__title").assertExists()
+        composeRule.onNodeWithTag("create-event-screen__title").assertTextEquals("Create event")
+    }
+
+    @Test
+    fun nameFieldExists() {
+        composeRule.onNodeWithTag("name").assertExists()
+        composeRule.onNodeWithTag("name").assert(hasText("name"))
+    }
+
+    @Test
+    fun nameSupportingTextExists() {
+        composeRule.onNodeWithTag("nameSupport", true).assertExists()
+    }
+
+    @Test
+    fun descriptionFieldExists() {
+        composeRule.onNodeWithTag("description").assertExists()
+        composeRule.onNodeWithTag("description").assert(hasText("description"))
+    }
+
+    @Test
+    fun descriptionSupportingTextExists() {
+        composeRule.onNodeWithTag("descriptionSupport", true).assertExists()
+    }
+
+    @Test
+    fun startDateTimeFieldExists() {
+        composeRule.onNodeWithTag("Start date and time (dd-mm-yyyy hh:mm)Field").assertExists()
+        composeRule.onNodeWithTag("Start date and time (dd-mm-yyyy hh:mm)Field").assert(hasText("Start date and time (dd-mm-yyyy hh:mm)"))
+    }
+
+    @Test
+    fun startDateTimeButtonExists() {
+        composeRule.onNodeWithTag("Start date and time (dd-mm-yyyy hh:mm)Button").assertExists()
+        composeRule.onNodeWithTag("Start date and time (dd-mm-yyyy hh:mm)Button").assertHasClickAction()
+    }
+
+    @Test
+    fun endDateTimeFieldExists() {
+        composeRule.onNodeWithTag("End date and time (dd-mm-yyyy hh:mm)Field").assertExists()
+        composeRule.onNodeWithTag("End date and time (dd-mm-yyyy hh:mm)Field").assert(hasText("End date and time (dd-mm-yyyy hh:mm)"))
+    }
+
+    @Test
+    fun endDateTimeButtonExists() {
+        composeRule.onNodeWithTag("End date and time (dd-mm-yyyy hh:mm)Button").assertExists()
+        composeRule.onNodeWithTag("End date and time (dd-mm-yyyy hh:mm)Button").assertHasClickAction()
+    }
+
+    @Test
+    fun latitudeFieldExists() {
+        composeRule.onNodeWithTag("latitude").assertExists()
+        composeRule.onNodeWithTag("latitude").assert(hasText("latitude"))
+    }
+
+    @Test
+    fun longitudeFieldExists() {
+        composeRule.onNodeWithTag("longitude").assertExists()
+        composeRule.onNodeWithTag("longitude").assert(hasText("longitude"))
+    }
+
+    @Test
+    fun pointsAwardedFieldExistsAndDisplaysCorrectly() {
+        composeRule.onNodeWithTag("pointsAwardedRow").assertExists()
+        composeRule.onNodeWithTag("pointsAwardedText").assertExists()
+        composeRule.onNodeWithTag("pointsAwardedText").assert(hasText("This event awards"))
+        composeRule.onNodeWithTag("pointsAwardedField").assertExists()
+        composeRule.onNodeWithTag("pointsAwardedValueText").assertExists()
+        composeRule.onNodeWithTag("pointsAwardedValueText").assert(hasText(" points."))
+    }
+
+    @Test
+    fun lateParticipationExistsAndDisplaysCorrectly() {
+        composeRule.onNodeWithTag("checkBoxRow").assertExists()
+        composeRule.onNodeWithTag("lateParticipationAllowedCheckbox").assertExists()
+        composeRule.onNodeWithTag("lateParticipationAllowedText").assert(hasText("Allow late participation to this event"))
+        composeRule.onNodeWithTag("lateParticipationAllowedText").assertExists()
+        composeRule.onNodeWithTag("lateParticipationAllowedCheckbox").assertHasClickAction()
+    }
+
+    @Test
+    fun createEventButtonExists() {
+        composeRule.onNodeWithTag("addActivity").assertExists()
+        composeRule.onNodeWithTag("addActivity").assert(hasText("Create event"))
+        composeRule.onNodeWithTag("addActivity").assertHasClickAction()
+    }
+
+    @Test
+    fun nameFieldWorks(){
+        composeRule.onNodeWithTag("name").performTextInput("name")
+        composeRule.onNodeWithTag("name").assert(hasText("name"))
+    }
+
+    @Test
+    fun nameFieldDoesNotAcceptMoreThan20Characters(){
+        composeRule.onNodeWithTag("name").performTextInput("123456789012345678901")
+        composeRule.onNodeWithTag("name").assert(!hasText("123456789012345678901"))
+    }
+
+    @Test
+    fun descriptionFieldDoesNotAcceptMoreThan200Characters(){
+        composeRule.onNodeWithTag("description").performTextInput("12345678901234567890".repeat(11))
+        composeRule.onNodeWithTag("description").assert(!hasText("12345678901234567890".repeat(11)))
+    }
+    @Test
+    fun descriptionFieldWorks(){
+        composeRule.onNodeWithTag("description").performTextInput("description")
+        composeRule.onNodeWithTag("description").assert(hasText("description"))
+    }
+
+    @Test
+    fun startDateTimeFieldWorks(){
+        composeRule.onNodeWithTag("Start date and time (dd-mm-yyyy hh:mm)Field").performTextInput("01-01-2021 12:00")
+        composeRule.onNodeWithTag("Start date and time (dd-mm-yyyy hh:mm)Field").assert(hasText("01-01-2021 12:00"))
+    }
+
+    @Test
+    fun endDateTimeFieldWorks(){
+        composeRule.onNodeWithTag("End date and time (dd-mm-yyyy hh:mm)Field").performScrollTo()
+        composeRule.onNodeWithTag("End date and time (dd-mm-yyyy hh:mm)Field").performTextInput("01-01-2021 13:00")
+        composeRule.onNodeWithTag("End date and time (dd-mm-yyyy hh:mm)Field").assert(hasText("01-01-2021 13:00"))
+    }
+
+    @Test
+    fun latitudeFieldWorks(){
+        composeRule.onNodeWithTag("latitude").performScrollTo()
+        composeRule.onNodeWithTag("latitude").performTextInput("1.0")
+        composeRule.onNodeWithTag("latitude").assert(hasText("1.0"))
+    }
+
+    @Test
+    fun longitudeFieldWorks(){
+        composeRule.onNodeWithTag("longitude").performScrollTo()
+        composeRule.onNodeWithTag("longitude").performTextInput("1.0")
+        composeRule.onNodeWithTag("longitude").assert(hasText("1.0"))
+    }
+
+    @Test
+    fun pointsAwardedFieldWorks(){
+        composeRule.onNodeWithTag("pointsAwardedField").performScrollTo()
+        composeRule.onNodeWithTag("pointsAwardedField").performTextInput("1")
+        composeRule.onNodeWithTag("pointsAwardedField").assert(hasText("1"))
+    }
+
+    @Test
+    fun lateParticipationAllowedCheckboxWorks(){
+        composeRule.onNodeWithTag("lateParticipationAllowedCheckbox").performScrollTo()
+        composeRule.onNodeWithTag("lateParticipationAllowedCheckbox").assertIsOff()
+        composeRule.onNodeWithTag("lateParticipationAllowedCheckbox").performClick()
+        composeRule.onNodeWithTag("lateParticipationAllowedCheckbox").assertIsOn()
+    }
+
+    @Test
+    fun eventWithAllInfoFilledInCanBeCreated() {
+        successCount = 0
+        composeRule.onNodeWithTag("name").performTextInput("name")
+        composeRule.onNodeWithTag("description").performTextInput("description")
+        composeRule.onNodeWithTag("Start date and time (dd-mm-yyyy hh:mm)Field").performTextInput("01-01-2021 12:00")
+        composeRule.onNodeWithTag("End date and time (dd-mm-yyyy hh:mm)Field").performScrollTo()
+        composeRule.onNodeWithTag("End date and time (dd-mm-yyyy hh:mm)Field").performTextInput("01-01-2021 13:00")
+        composeRule.onNodeWithTag("latitude").performScrollTo()
+        composeRule.onNodeWithTag("latitude").performTextInput("1.0")
+        composeRule.onNodeWithTag("longitude").performScrollTo()
+        composeRule.onNodeWithTag("longitude").performTextInput("1.0")
+        composeRule.onNodeWithTag("pointsAwardedField").performScrollTo()
+        composeRule.onNodeWithTag("pointsAwardedField").performTextInput("1")
+        composeRule.onNodeWithTag("lateParticipationAllowedCheckbox").performScrollTo()
+        composeRule.onNodeWithTag("lateParticipationAllowedCheckbox").performClick()
+        composeRule.onNodeWithTag("addActivity").performScrollTo()
+        composeRule.onNodeWithTag("addActivity").performClick()
+        Thread.sleep(500)
+        Assert.assertEquals(1, successCount)
+    }
+
+    @Test
+    fun eventWithNoNameCannotBeCreated() {
+        successCount = 0
+        composeRule.onNodeWithTag("description").performTextInput("description")
+        composeRule.onNodeWithTag("Start date and time (dd-mm-yyyy hh:mm)Field").performTextInput("01-01-2021 12:00")
+        composeRule.onNodeWithTag("End date and time (dd-mm-yyyy hh:mm)Field").performTextInput("01-01-2021 13:00")
+        composeRule.onNodeWithTag("latitude").performTextInput("1.0")
+        composeRule.onNodeWithTag("longitude").performTextInput("1.0")
+        composeRule.onNodeWithTag("pointsAwardedField").performTextInput("1")
+        composeRule.onNodeWithTag("lateParticipationAllowedCheckbox").performClick()
+        composeRule.onNodeWithTag("addActivity").performClick()
+        Thread.sleep(500)
+        Assert.assertEquals(0, successCount)
+    }
+
+    @Test
+    fun eventWithNoDescriptionCannotBeCreated() {
+        successCount = 0
+        composeRule.onNodeWithTag("name").performTextInput("name")
+        composeRule.onNodeWithTag("Start date and time (dd-mm-yyyy hh:mm)Field").performTextInput("01-01-2021 12:00")
+        composeRule.onNodeWithTag("End date and time (dd-mm-yyyy hh:mm)Field").performTextInput("01-01-2021 13:00")
+        composeRule.onNodeWithTag("latitude").performTextInput("1.0")
+        composeRule.onNodeWithTag("longitude").performTextInput("1.0")
+        composeRule.onNodeWithTag("pointsAwardedField").performTextInput("1")
+        composeRule.onNodeWithTag("lateParticipationAllowedCheckbox").performClick()
+        composeRule.onNodeWithTag("addActivity").performClick()
+        Thread.sleep(500)
+        Assert.assertEquals(0, successCount)
+    }
+
+    @Test
+    fun eventWithNoStartDateTimeCannotBeCreated() {
+        successCount = 0
+        composeRule.onNodeWithTag("name").performTextInput("name")
+        composeRule.onNodeWithTag("description").performTextInput("description")
+        composeRule.onNodeWithTag("End date and time (dd-mm-yyyy hh:mm)Field").performTextInput("01-01-2021 13:00")
+        composeRule.onNodeWithTag("latitude").performTextInput("1.0")
+        composeRule.onNodeWithTag("longitude").performTextInput("1.0")
+        composeRule.onNodeWithTag("pointsAwardedField").performTextInput("1")
+        composeRule.onNodeWithTag("lateParticipationAllowedCheckbox").performClick()
+        composeRule.onNodeWithTag("addActivity").performClick()
+        Thread.sleep(500)
+        Assert.assertEquals(0, successCount)
+    }
+
+    @Test
+    fun eventWithNoEndDateTimeCannotBeCreated() {
+        successCount = 0
+        composeRule.onNodeWithTag("name").performTextInput("name")
+        composeRule.onNodeWithTag("description").performTextInput("description")
+        composeRule.onNodeWithTag("Start date and time (dd-mm-yyyy hh:mm)Field").performTextInput("01-01-2021 12:00")
+        composeRule.onNodeWithTag("latitude").performTextInput("1.0")
+        composeRule.onNodeWithTag("longitude").performTextInput("1.0")
+        composeRule.onNodeWithTag("pointsAwardedField").performTextInput("1")
+        composeRule.onNodeWithTag("lateParticipationAllowedCheckbox").performClick()
+        composeRule.onNodeWithTag("addActivity").performClick()
+        Thread.sleep(500)
+        Assert.assertEquals(0, successCount)
+    }
+
+    @Test
+    fun eventWithNoLatitudeCannotBeCreated() {
+        successCount = 0
+        composeRule.onNodeWithTag("name").performTextInput("name")
+        composeRule.onNodeWithTag("description").performTextInput("description")
+        composeRule.onNodeWithTag("Start date and time (dd-mm-yyyy hh:mm)Field").performTextInput("01-01-2021 12:00")
+        composeRule.onNodeWithTag("End date and time (dd-mm-yyyy hh:mm)Field").performTextInput("01-01-2021 13:00")
+        composeRule.onNodeWithTag("longitude").performTextInput("1.0")
+        composeRule.onNodeWithTag("pointsAwardedField").performTextInput("1")
+        composeRule.onNodeWithTag("lateParticipationAllowedCheckbox").performClick()
+        composeRule.onNodeWithTag("addActivity").performClick()
+        Thread.sleep(500)
+        Assert.assertEquals(0, successCount)
+    }
+
+    @Test
+    fun eventWithNoLongitudeCannotBeCreated() {
+        successCount = 0
+        composeRule.onNodeWithTag("name").performTextInput("name")
+        composeRule.onNodeWithTag("description").performTextInput("description")
+        composeRule.onNodeWithTag("Start date and time (dd-mm-yyyy hh:mm)Field").performTextInput("01-01-2021 12:00")
+        composeRule.onNodeWithTag("End date and time (dd-mm-yyyy hh:mm)Field").performTextInput("01-01-2021 13:00")
+        composeRule.onNodeWithTag("latitude").performTextInput("1.0")
+        composeRule.onNodeWithTag("pointsAwardedField").performTextInput("1")
+        composeRule.onNodeWithTag("lateParticipationAllowedCheckbox").performClick()
+        composeRule.onNodeWithTag("addActivity").performClick()
+        Thread.sleep(500)
+        Assert.assertEquals(0, successCount)
+    }
+
+    @Test
+    fun eventWithNoPointsAwardedCannotBeCreated() {
+        successCount = 0
+        composeRule.onNodeWithTag("name").performTextInput("name")
+        composeRule.onNodeWithTag("description").performTextInput("description")
+        composeRule.onNodeWithTag("Start date and time (dd-mm-yyyy hh:mm)Field")
+            .performTextInput("01-01-2021 12:00")
+        composeRule.onNodeWithTag("longitude").performScrollTo()
+        composeRule.onNodeWithTag("End date and time (dd-mm-yyyy hh:mm)Field")
+            .performTextInput("01-01-2021 13:00")
+        composeRule.onNodeWithTag("latitude").performTextInput("1.0")
+        composeRule.onNodeWithTag("longitude").performTextInput("1.0")
+        composeRule.onNodeWithTag("addActivity").performScrollTo()
+        composeRule.onNodeWithTag("lateParticipationAllowedCheckbox").performClick()
+        composeRule.onNodeWithTag("addActivity").performClick()
+        Thread.sleep(500)
+        Assert.assertEquals(0, successCount)
+    }
+
+    @Test
+    fun eventWithInvalidStartMonthCannotBeCreated(){
+        successCount = 0
+        composeRule.onNodeWithTag("name").performTextInput("name")
+        composeRule.onNodeWithTag("description").performTextInput("description")
+        composeRule.onNodeWithTag("Start date and time (dd-mm-yyyy hh:mm)Field")
+            .performTextInput("01-13-2021 12:00")
+        composeRule.onNodeWithTag("longitude").performScrollTo()
+        composeRule.onNodeWithTag("End date and time (dd-mm-yyyy hh:mm)Field")
+            .performTextInput("01-01-2021 13:00")
+        composeRule.onNodeWithTag("latitude").performTextInput("1.0")
+        composeRule.onNodeWithTag("longitude").performTextInput("1.0")
+        composeRule.onNodeWithTag("pointsAwardedField").performTextInput("1")
+        composeRule.onNodeWithTag("addActivity").performScrollTo()
+        composeRule.onNodeWithTag("lateParticipationAllowedCheckbox").performClick()
+        composeRule.onNodeWithTag("addActivity").performClick()
+        Thread.sleep(500)
+        Assert.assertEquals(0, successCount)
+    }
+
+    @Test
+    fun eventWithInvalidStartHourCannotBeCreated(){
+        successCount = 0
+        composeRule.onNodeWithTag("name").performTextInput("name")
+        composeRule.onNodeWithTag("description").performTextInput("description")
+        composeRule.onNodeWithTag("Start date and time (dd-mm-yyyy hh:mm)Field")
+            .performTextInput("01-01-2021 25:00")
+        composeRule.onNodeWithTag("longitude").performScrollTo()
+        composeRule.onNodeWithTag("End date and time (dd-mm-yyyy hh:mm)Field")
+            .performTextInput("01-01-2021 13:00")
+        composeRule.onNodeWithTag("latitude").performTextInput("1.0")
+        composeRule.onNodeWithTag("longitude").performTextInput("1.0")
+        composeRule.onNodeWithTag("pointsAwardedField").performTextInput("1")
+        composeRule.onNodeWithTag("addActivity").performScrollTo()
+        composeRule.onNodeWithTag("lateParticipationAllowedCheckbox").performClick()
+        composeRule.onNodeWithTag("addActivity").performClick()
+        Thread.sleep(500)
+        Assert.assertEquals(0, successCount)
+    }
+
+    @Test
+    fun eventWithInvalidEndMonthCannotBeCreated(){
+        successCount = 0
+        composeRule.onNodeWithTag("name").performTextInput("name")
+        composeRule.onNodeWithTag("description").performTextInput("description")
+        composeRule.onNodeWithTag("Start date and time (dd-mm-yyyy hh:mm)Field")
+            .performTextInput("01-01-2021 12:00")
+        composeRule.onNodeWithTag("longitude").performScrollTo()
+        composeRule.onNodeWithTag("End date and time (dd-mm-yyyy hh:mm)Field")
+            .performTextInput("01-13-2021 13:00")
+        composeRule.onNodeWithTag("latitude").performTextInput("1.0")
+        composeRule.onNodeWithTag("longitude").performTextInput("1.0")
+        composeRule.onNodeWithTag("pointsAwardedField").performTextInput("1")
+        composeRule.onNodeWithTag("addActivity").performScrollTo()
+        composeRule.onNodeWithTag("lateParticipationAllowedCheckbox").performClick()
+        composeRule.onNodeWithTag("addActivity").performClick()
+        Thread.sleep(500)
+        Assert.assertEquals(0, successCount)
+    }
+
+    @Test
+    fun eventWithInvalidEndHourCannotBeCreated(){
+        successCount = 0
+        composeRule.onNodeWithTag("name").performTextInput("name")
+        composeRule.onNodeWithTag("description").performTextInput("description")
+        composeRule.onNodeWithTag("Start date and time (dd-mm-yyyy hh:mm)Field")
+            .performTextInput("01-01-2021 12:00")
+        composeRule.onNodeWithTag("longitude").performScrollTo()
+        composeRule.onNodeWithTag("End date and time (dd-mm-yyyy hh:mm)Field")
+            .performTextInput("01-01-2021 25:00")
+        composeRule.onNodeWithTag("latitude").performTextInput("1.0")
+        composeRule.onNodeWithTag("longitude").performTextInput("1.0")
+        composeRule.onNodeWithTag("pointsAwardedField").performTextInput("1")
+        composeRule.onNodeWithTag("addActivity").performScrollTo()
+        composeRule.onNodeWithTag("lateParticipationAllowedCheckbox").performClick()
+        composeRule.onNodeWithTag("addActivity").performClick()
+        Thread.sleep(500)
+        Assert.assertEquals(0, successCount)
+    }
+
+    @Test
+    fun eventWithInvalidStartMinuteCannotBeCreated(){
+        successCount = 0
+        composeRule.onNodeWithTag("name").performTextInput("name")
+        composeRule.onNodeWithTag("description").performTextInput("description")
+        composeRule.onNodeWithTag("Start date and time (dd-mm-yyyy hh:mm)Field")
+            .performTextInput("01-01-2021 12:60")
+        composeRule.onNodeWithTag("longitude").performScrollTo()
+        composeRule.onNodeWithTag("End date and time (dd-mm-yyyy hh:mm)Field")
+            .performTextInput("01-01-2021 13:00")
+        composeRule.onNodeWithTag("latitude").performTextInput("1.0")
+        composeRule.onNodeWithTag("longitude").performTextInput("1.0")
+        composeRule.onNodeWithTag("pointsAwardedField").performTextInput("1")
+        composeRule.onNodeWithTag("addActivity").performScrollTo()
+        composeRule.onNodeWithTag("lateParticipationAllowedCheckbox").performClick()
+        composeRule.onNodeWithTag("addActivity").performClick()
+        Thread.sleep(500)
+        Assert.assertEquals(0, successCount)
+    }
+
+    @Test
+    fun eventWithInvalidEndMinuteCannotBeCreated(){
+        successCount = 0
+        composeRule.onNodeWithTag("name").performTextInput("name")
+        composeRule.onNodeWithTag("description").performTextInput("description")
+        composeRule.onNodeWithTag("Start date and time (dd-mm-yyyy hh:mm)Field")
+            .performTextInput("01-01-2021 12:00")
+        composeRule.onNodeWithTag("longitude").performScrollTo()
+        composeRule.onNodeWithTag("End date and time (dd-mm-yyyy hh:mm)Field")
+            .performTextInput("01-01-2021 13:60")
+        composeRule.onNodeWithTag("latitude").performTextInput("1.0")
+        composeRule.onNodeWithTag("longitude").performTextInput("1.0")
+        composeRule.onNodeWithTag("pointsAwardedField").performTextInput("1")
+        composeRule.onNodeWithTag("addActivity").performScrollTo()
+        composeRule.onNodeWithTag("lateParticipationAllowedCheckbox").performClick()
+        composeRule.onNodeWithTag("addActivity").performClick()
+        Thread.sleep(500)
+        Assert.assertEquals(0, successCount)
+    }
+
+    @Test
+    fun eventWithStartDateTimeAfterEndDateTimeCannotBeCreated(){
+        successCount = 0
+        composeRule.onNodeWithTag("name").performTextInput("name")
+        composeRule.onNodeWithTag("description").performTextInput("description")
+        composeRule.onNodeWithTag("Start date and time (dd-mm-yyyy hh:mm)Field")
+            .performTextInput("02-01-2021 12:00")
+        composeRule.onNodeWithTag("longitude").performScrollTo()
+        composeRule.onNodeWithTag("End date and time (dd-mm-yyyy hh:mm)Field")
+            .performTextInput("01-01-2021 13:00")
+        composeRule.onNodeWithTag("latitude").performTextInput("1.0")
+        composeRule.onNodeWithTag("longitude").performTextInput("1.0")
+        composeRule.onNodeWithTag("pointsAwardedField").performTextInput("1")
+        composeRule.onNodeWithTag("addActivity").performScrollTo()
+        composeRule.onNodeWithTag("lateParticipationAllowedCheckbox").performClick()
+        composeRule.onNodeWithTag("addActivity").performClick()
+        Thread.sleep(500)
+        Assert.assertEquals(0, successCount)
+    }
+
+    @Test
+    fun eventWithInvalidLatitudeCannotBeCreated(){
+        successCount = 0
+        composeRule.onNodeWithTag("name").performTextInput("name")
+        composeRule.onNodeWithTag("description").performTextInput("description")
+        composeRule.onNodeWithTag("Start date and time (dd-mm-yyyy hh:mm)Field")
+            .performTextInput("01-01-2021 12:00")
+        composeRule.onNodeWithTag("longitude").performScrollTo()
+        composeRule.onNodeWithTag("End date and time (dd-mm-yyyy hh:mm)Field")
+            .performTextInput("01-01-2021 13:00")
+        composeRule.onNodeWithTag("latitude").performTextInput("91.0")
+        composeRule.onNodeWithTag("longitude").performTextInput("1.0")
+        composeRule.onNodeWithTag("pointsAwardedField").performTextInput("1")
+        composeRule.onNodeWithTag("addActivity").performScrollTo()
+        composeRule.onNodeWithTag("lateParticipationAllowedCheckbox").performClick()
+        composeRule.onNodeWithTag("addActivity").performClick()
+        Thread.sleep(500)
+        Assert.assertEquals(0, successCount)
+    }
+
+    @Test
+    fun eventWithInvalidLongitudeCannotBeCreated(){
+        successCount = 0
+        composeRule.onNodeWithTag("name").performTextInput("name")
+        composeRule.onNodeWithTag("description").performTextInput("description")
+        composeRule.onNodeWithTag("Start date and time (dd-mm-yyyy hh:mm)Field")
+            .performTextInput("01-01-2021 12:00")
+        composeRule.onNodeWithTag("longitude").performScrollTo()
+        composeRule.onNodeWithTag("End date and time (dd-mm-yyyy hh:mm)Field")
+            .performTextInput("01-01-2021 13:00")
+        composeRule.onNodeWithTag("latitude").performTextInput("1.0")
+        composeRule.onNodeWithTag("longitude").performTextInput("181.0")
+        composeRule.onNodeWithTag("pointsAwardedField").performTextInput("1")
+        composeRule.onNodeWithTag("addActivity").performScrollTo()
+        composeRule.onNodeWithTag("lateParticipationAllowedCheckbox").performClick()
+        composeRule.onNodeWithTag("addActivity").performClick()
+        Thread.sleep(500)
+        Assert.assertEquals(0, successCount)
+    }
+
+    @Test
+    fun eventWithInvalidPointsAwardedCannotBeCreated(){
+        successCount = 0
+        composeRule.onNodeWithTag("name").performTextInput("name")
+        composeRule.onNodeWithTag("description").performTextInput("description")
+        composeRule.onNodeWithTag("Start date and time (dd-mm-yyyy hh:mm)Field")
+            .performTextInput("01-01-2021 12:00")
+        composeRule.onNodeWithTag("longitude").performScrollTo()
+        composeRule.onNodeWithTag("End date and time (dd-mm-yyyy hh:mm)Field")
+            .performTextInput("01-01-2021 13:00")
+        composeRule.onNodeWithTag("latitude").performTextInput("1.0")
+        composeRule.onNodeWithTag("longitude").performTextInput("1.0")
+        composeRule.onNodeWithTag("pointsAwardedField").performTextInput("-1")
+        composeRule.onNodeWithTag("addActivity").performScrollTo()
+        composeRule.onNodeWithTag("lateParticipationAllowedCheckbox").performClick()
+        composeRule.onNodeWithTag("addActivity").performClick()
+        Thread.sleep(500)
+        Assert.assertEquals(0, successCount)
+    }
+
+
+
+
+}

--- a/app/src/androidTest/java/com/github/studydistractor/sdp/ui/EventHistoryScreenTest.kt
+++ b/app/src/androidTest/java/com/github/studydistractor/sdp/ui/EventHistoryScreenTest.kt
@@ -1,0 +1,59 @@
+package com.github.studydistractor.sdp.ui
+
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import com.github.studydistractor.sdp.createUser.CreateUserViewModel
+import com.github.studydistractor.sdp.eventChat.EventChatViewModel
+import com.github.studydistractor.sdp.eventHistory.EventHistoryViewModel
+import com.github.studydistractor.sdp.fakeServices.CreateUserServiceFake
+import com.github.studydistractor.sdp.fakeServices.EventChatServiceFake
+import com.github.studydistractor.sdp.fakeServices.EventHistoryServiceFake
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class EventHistoryScreenTest {
+    @get:Rule(order = 1)
+    val composeRule = createComposeRule()
+
+    @Before
+    fun setup() {
+        composeRule.setContent {
+            EventHistoryScreen(
+                eventHistoryViewModel = EventHistoryViewModel(EventHistoryServiceFake()),
+                chatViewModel = EventChatViewModel(EventChatServiceFake()),
+                onChatButtonClicked = {})
+        }
+    }
+
+    @Test
+    fun testTitleIsDisplayed(){
+        composeRule.onNodeWithTag("event-history-screen__title").assertIsDisplayed()
+    }
+
+    @Test
+    fun testCardsThatShouldBeDisplayed(){
+        composeRule.onNodeWithTag("event-history-card__title event1").assertExists()
+        composeRule.onNodeWithTag("event-history-card__title event1").assertIsDisplayed()
+        composeRule.onNodeWithTag("event-history-card__title event1").assertHasClickAction()
+
+        composeRule.onNodeWithTag("event-history-card__title event2").assertExists()
+        composeRule.onNodeWithTag("event-history-card__title event2").assertIsDisplayed()
+        composeRule.onNodeWithTag("event-history-card__title event2").assertHasClickAction()
+
+        composeRule.onNodeWithTag("event-history-card__title event3").assertExists()
+        composeRule.onNodeWithTag("event-history-card__title event3").assertIsDisplayed()
+        composeRule.onNodeWithTag("event-history-card__title event3").assertHasClickAction()
+    }
+
+    @Test
+    fun testCardsThatShouldNotBeDisplayed(){
+        composeRule.onNodeWithTag("event-history-card__title NotFinishedEvent").assertDoesNotExist()
+        composeRule.onNodeWithTag("event-history-card__title UserHasNotTakenPartIn").assertDoesNotExist()
+    }
+
+}

--- a/app/src/main/java/com/github/studydistractor/sdp/StudyDistractorScreen.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/StudyDistractorScreen.kt
@@ -1,6 +1,7 @@
 package com.github.studydistractor.sdp
 
 import android.content.Intent
+import android.widget.Toast
 import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -18,6 +19,8 @@ import androidx.navigation.compose.rememberNavController
 import com.github.studydistractor.sdp.account.FriendsServiceFirebase
 import com.github.studydistractor.sdp.createDistraction.CreateDistractionServiceFirebase
 import com.github.studydistractor.sdp.createDistraction.CreateDistractionViewModel
+import com.github.studydistractor.sdp.createEvent.CreateEventServiceFirebase
+import com.github.studydistractor.sdp.createEvent.CreateEventViewModel
 import com.github.studydistractor.sdp.createUser.CreateUserServiceFirebase
 import com.github.studydistractor.sdp.createUser.CreateUserViewModel
 import com.github.studydistractor.sdp.dailyChallenge.DailyChallengeServiceFirebase
@@ -29,6 +32,8 @@ import com.github.studydistractor.sdp.distractionStat.DistractionStatServiceFire
 import com.github.studydistractor.sdp.distractionStat.DistractionStatViewModel
 import com.github.studydistractor.sdp.eventChat.EventChatServiceFirebase
 import com.github.studydistractor.sdp.eventChat.EventChatViewModel
+import com.github.studydistractor.sdp.eventHistory.EventHistoryServiceFirebase
+import com.github.studydistractor.sdp.eventHistory.EventHistoryViewModel
 import com.github.studydistractor.sdp.friends.FriendsViewModel
 import com.github.studydistractor.sdp.history.HistoryServiceFirebase
 import com.github.studydistractor.sdp.history.HistoryViewModel
@@ -56,7 +61,9 @@ enum class StudyDistractorScreen(@StringRes val title: Int) {
     History(title = R.string.screen_name_history),
     CreateUser(title = R.string.screen_name_create_user),
     DailyChallenge(title = R.string.screen_name_daily_challenge),
-    ChatEvent(title = R.string.screen_name_chat_event)
+    ChatEvent(title = R.string.screen_name_chat_event),
+    EventHistory(title = R.string.screen_name_event_history),
+    CreateEvent(title = R.string.screen_name_create_event),
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -96,6 +103,10 @@ fun StudyDistractorApp(
         remember { DailyChallengeViewModel(DailyChallengeServiceFirebase()) }
     val chatEventViewModel =
         remember { EventChatViewModel(EventChatServiceFirebase())}
+    val eventHistoryViewModel =
+        remember { EventHistoryViewModel(EventHistoryServiceFirebase())}
+    val createEventViewModel =
+        remember { CreateEventViewModel(CreateEventServiceFirebase()) }
 
     Scaffold(
         topBar = { AppBarTop(
@@ -110,7 +121,10 @@ fun StudyDistractorApp(
             },
             goToMapActivity = {
                 context.startActivity(Intent(context, MapsActivity::class.java))
-            }
+            },
+            goToCreateEventActivity = {
+                navController.navigate(StudyDistractorScreen.CreateEvent.name)
+            },
         ) },
         bottomBar = { AppBarBottom(
             onHomeClick = { navController.navigate(StudyDistractorScreen.Login.name) },
@@ -185,6 +199,14 @@ fun StudyDistractorApp(
                     }
                 )
             }
+            composable(route = StudyDistractorScreen.CreateEvent.name)  {
+                CreateEventScreen(
+                    createEventViewModel = createEventViewModel,
+                    onEventCreated = {
+                        Toast.makeText(context, "Event created", Toast.LENGTH_SHORT).show()
+                    }
+                )
+            }
             composable(route = StudyDistractorScreen.History.name) {
                 HistoryScreen(
                     historyViewModel = historyViewModel
@@ -207,6 +229,15 @@ fun StudyDistractorApp(
             }
             composable(route = StudyDistractorScreen.ChatEvent.name){
                 EventChatScreen(chatEventViewModel)
+            }
+            composable(route = StudyDistractorScreen.EventHistory.name){
+                EventHistoryScreen(
+                    eventHistoryViewModel = eventHistoryViewModel,
+                    chatViewModel = chatEventViewModel,
+                    onChatButtonClicked = {
+                        navController.navigate(StudyDistractorScreen.ChatEvent.name)
+                    }
+                )
             }
         }
     }

--- a/app/src/main/java/com/github/studydistractor/sdp/createActivity/CreateActivityViewModel.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/createActivity/CreateActivityViewModel.kt
@@ -1,0 +1,41 @@
+package com.github.studydistractor.sdp.createActivity
+
+import com.github.studydistractor.sdp.ui.state.CreateActivityUiState
+import com.google.android.gms.tasks.Task
+import kotlinx.coroutines.flow.StateFlow
+
+interface CreateActivityViewModel {
+
+    val uiState: StateFlow<CreateActivityUiState>
+
+    /**
+     * Update the name
+     *
+     * @name(String): the new name
+     */
+    fun updateName(name: String)
+
+    /**
+     * Update the description
+     *
+     * @description(String): the new description
+     */
+    fun updateDescription(description: String)
+
+    /**
+     * Update the latitude
+     * @latitude(String): the new latitude
+     */
+    fun updateLatitude(latitude: String)
+
+    /**
+     * Update the longitude
+     * @longitude(String): the new longitude
+     */
+    fun updateLongitude(longitude: String)
+
+    /**
+     * Create a new activity (event or distraction) in the db
+     */
+    fun createActivity(): Task<Void>
+}

--- a/app/src/main/java/com/github/studydistractor/sdp/createDistraction/CreateDistractionViewModel.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/createDistraction/CreateDistractionViewModel.kt
@@ -1,8 +1,9 @@
 package com.github.studydistractor.sdp.createDistraction
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
+import com.github.studydistractor.sdp.createActivity.CreateActivityViewModel
 import com.github.studydistractor.sdp.data.Distraction
-import com.github.studydistractor.sdp.ui.DistractionScreenConstants
 import com.github.studydistractor.sdp.ui.state.CreateDistractionUiState
 import com.google.android.gms.tasks.Task
 import com.google.android.gms.tasks.Tasks
@@ -11,12 +12,20 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 
+object CreateDistractionViewModelConstants {
+    const val MAX_NAME_LENGTH = 20
+    const val MAX_DESCRIPTION_LENGTH = 200
+    const val MAX_LATITUDE = 90.0
+    const val MIN_LATITUDE = -90.0
+    const val MAX_LONGITUDE = 180.0
+    const val MIN_LONGITUDE = -180.0
+}
 class CreateDistractionViewModel(
     createDistractionModel: CreateDistractionModel
-) : ViewModel() {
+) : CreateActivityViewModel, ViewModel() {
     private val _createDistractionModel: CreateDistractionModel = createDistractionModel
     private val _uiState = MutableStateFlow(CreateDistractionUiState())
-    val uiState: StateFlow<CreateDistractionUiState> = _uiState.asStateFlow()
+    override val uiState: StateFlow<CreateDistractionUiState> = _uiState.asStateFlow()
 
 
     /**
@@ -24,13 +33,15 @@ class CreateDistractionViewModel(
      *
      * @name(String): the new name
      */
-    fun updateName(name: String) {
-        if(name.length > DistractionScreenConstants.MAX_NAME_LENGTH) return
+    override fun updateName(name: String) {
+        if (name.length > CreateDistractionViewModelConstants.MAX_NAME_LENGTH) return
 
-        _uiState.update { it.copy(
-            name = name,
-            supportingTextName = "${name.length}/${DistractionScreenConstants.MAX_NAME_LENGTH}",
-        ) }
+        _uiState.update {
+            it.copy(
+                name = name,
+                supportingTextName = "${name.length}/${CreateDistractionViewModelConstants.MAX_NAME_LENGTH}",
+            )
+        }
     }
 
     /**
@@ -38,34 +49,97 @@ class CreateDistractionViewModel(
      *
      * @description(String): the new description
      */
-    fun updateDescription(description: String) {
-        if(description.length > DistractionScreenConstants.MAX_DESCRIPTION_LENGTH) return
+    override fun updateDescription(description: String) {
+        if (description.length > CreateDistractionViewModelConstants.MAX_DESCRIPTION_LENGTH) return
 
-        _uiState.update { it.copy(
-            description = description,
-            supportingTextDescription = "${description.length}/${DistractionScreenConstants.MAX_DESCRIPTION_LENGTH}",
-        ) }
+        _uiState.update {
+            it.copy(
+                description = description,
+                supportingTextDescription = "${description.length}/${CreateDistractionViewModelConstants.MAX_DESCRIPTION_LENGTH}",
+            )
+        }
+    }
+
+    override fun updateLatitude(latitude: String) {
+        _uiState.update {
+            it.copy(latitude = latitude)
+        }
+    }
+
+    override fun updateLongitude(longitude: String) {
+        _uiState.update {
+            it.copy(longitude = longitude)
+        }
     }
 
     /**
      * Create a distraction using the data from uiState
      */
-    fun createDistraction() : Task<Void> {
-        if(uiState.value.description.length > DistractionScreenConstants.MAX_DESCRIPTION_LENGTH) {
-            return Tasks.forException(Exception("Name is too long"))
-        }
-
-        if(uiState.value.name.length > DistractionScreenConstants.MAX_NAME_LENGTH) {
-            return Tasks.forException(Exception("Description is too long"))
-        }
-
-        if(uiState.value.name == "" || uiState.value.description == "") {
+    override fun createActivity(): Task<Void> {
+        if (uiState.value.name == "" || uiState.value.description == "") {
             return Tasks.forException(Exception("Please fill in the blanks"))
         }
+        if ((!uiState.value.latitude.isNullOrBlank()) && (!uiState.value.longitude.isNullOrBlank())) {
+            Log.d("CreateDistractionViewModel", "Latitude: ${uiState.value.latitude}, Longitude: ${uiState.value.longitude}")
+            if (!validateLatitude() || !validateLongitude()) {
+                return Tasks.forException(Exception("Invalid latitude or longitude"))
+            }
+            return _createDistractionModel.createDistraction(
+                Distraction(
+                    name = uiState.value.name,
+                    description = uiState.value.description,
+                    lat = uiState.value.latitude?.toDouble(),
+                    long = uiState.value.longitude?.toDouble()
+                )
+            )
+        }
+        if ((uiState.value.latitude.isNullOrBlank()) xor (uiState.value.longitude.isNullOrBlank())){
+            return Tasks.forException(Exception("Please fill in both latitude and longitude"))
+        }
 
-        return _createDistractionModel.createDistraction(Distraction(
-            name = uiState.value.name,
-            description = uiState.value.description
-        ))
+        return _createDistractionModel.createDistraction(
+            Distraction(
+                name = uiState.value.name,
+                description = uiState.value.description
+            )
+        )
+    }
+
+    /**
+     * Update the visibility of the location fields.
+     * @param isVisible: the new visibility
+     */
+    fun updateLocationFieldIsVisible(isVisible: Boolean) {
+        _uiState.update {
+            it.copy(
+                locationFieldIsVisible = isVisible
+            )
+        }
+    }
+
+    /**
+     * Validates the latitude value stored in the current UI state.
+     *
+     * @return True if the latitude value is valid and false otherwise.
+     */
+    private fun validateLatitude(): Boolean {
+        val latitudeDouble = uiState.value.latitude?.toDoubleOrNull() ?: return false
+
+        if (latitudeDouble < CreateDistractionViewModelConstants.MIN_LATITUDE || latitudeDouble > CreateDistractionViewModelConstants.MAX_LATITUDE) return false
+
+        return true
+    }
+
+    /**
+     * Validates the longitude value stored in the current UI state.
+     *
+     * @return True if the longitude value is valid and false otherwise.
+     */
+    private fun validateLongitude(): Boolean {
+        val longitudeDouble = uiState.value.longitude?.toDoubleOrNull() ?: return false
+
+        if (longitudeDouble < CreateDistractionViewModelConstants.MIN_LONGITUDE || longitudeDouble > CreateDistractionViewModelConstants.MAX_LONGITUDE) return false
+
+        return true
     }
 }

--- a/app/src/main/java/com/github/studydistractor/sdp/createEvent/CreateEventModel.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/createEvent/CreateEventModel.kt
@@ -1,0 +1,11 @@
+package com.github.studydistractor.sdp.createEvent
+
+import com.google.android.gms.tasks.Task
+
+interface CreateEventModel {
+    /**
+     * Create an event in the db
+     * @event(Event): the event to add
+     */
+    fun createEvent(eventInformation: Map<String, Any?>): Task<Void>
+}

--- a/app/src/main/java/com/github/studydistractor/sdp/createEvent/CreateEventServiceFirebase.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/createEvent/CreateEventServiceFirebase.kt
@@ -1,0 +1,28 @@
+package com.github.studydistractor.sdp.createEvent
+
+import com.github.studydistractor.sdp.data.FirebaseChat
+import com.github.studydistractor.sdp.data.FirebaseEvent
+import com.google.android.gms.tasks.Task
+import com.google.firebase.database.DatabaseReference
+import com.google.firebase.database.FirebaseDatabase
+
+class CreateEventServiceFirebase : CreateEventModel {
+    private val eventsDB: DatabaseReference = FirebaseDatabase.getInstance().getReference("Events")
+    private val chatDB: DatabaseReference = FirebaseDatabase.getInstance().getReference("ChatEvent")
+    override fun createEvent(eventInformation: Map<String, Any?>): Task<Void> {
+        val chatRef = chatDB.push()
+        val eventRef = eventsDB.push()
+        chatRef.setValue(FirebaseChat(chatRef.key as String))
+        return eventRef.setValue(
+            FirebaseEvent(
+                eventRef.key as String,
+                eventInformation["name"] as String, eventInformation["description"] as String,
+                eventInformation["latitude"] as Double, eventInformation["longitude"] as Double,
+                eventInformation["startDateTime"] as String, eventInformation["endDateTime"] as String,
+                eventInformation["lateParticipationAllowed"] as Boolean, eventInformation["points"] as Int,
+                chatRef.key as String
+            )
+        )
+
+    }
+}

--- a/app/src/main/java/com/github/studydistractor/sdp/createEvent/CreateEventViewModel.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/createEvent/CreateEventViewModel.kt
@@ -1,0 +1,327 @@
+package com.github.studydistractor.sdp.createEvent
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import com.github.studydistractor.sdp.createActivity.CreateActivityViewModel
+import com.github.studydistractor.sdp.ui.state.CreateEventUiState
+import com.google.android.gms.tasks.Task
+import com.google.android.gms.tasks.Tasks
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import java.text.ParseException
+import java.text.SimpleDateFormat
+import java.util.Calendar
+
+object EventViewModelConstants {
+    const val MAX_NAME_LENGTH = 20
+    const val MAX_DESCRIPTION_LENGTH = 200
+    const val MAX_LATITUDE = 90.0
+    const val MIN_LATITUDE = -90.0
+    const val MAX_LONGITUDE = 180.0
+    const val MIN_LONGITUDE = -180.0
+    const val DATE_TIME_FORMAT_REGEX = "^(\\d{2})-(\\d{2})-(\\d{4}) (\\d{2}):(\\d{2})\$"
+    const val MIN_POINTS = 0
+    const val MAX_POINTS = 100
+}
+
+class CreateEventViewModel(
+    createEventModel: CreateEventModel
+) : CreateActivityViewModel, ViewModel() {
+    private val _createEventModel: CreateEventModel = createEventModel
+    private val _uiState = MutableStateFlow(CreateEventUiState())
+    override val uiState: StateFlow<CreateEventUiState> = _uiState.asStateFlow()
+
+    override fun updateName(name: String) {
+        if (name.length > EventViewModelConstants.MAX_NAME_LENGTH) return
+
+        _uiState.update {
+            it.copy(
+                name = name,
+                supportingTextName = "${name.length}/${EventViewModelConstants.MAX_NAME_LENGTH}",
+            )
+        }
+    }
+
+    override fun updateDescription(description: String) {
+        if (description.length > EventViewModelConstants.MAX_DESCRIPTION_LENGTH) return
+
+        _uiState.update {
+            it.copy(
+                description = description,
+                supportingTextDescription = "${description.length}/${EventViewModelConstants.MAX_DESCRIPTION_LENGTH}",
+            )
+        }
+    }
+
+    override fun updateLatitude(latitude: String) {
+        _uiState.update {
+            it.copy(latitude = latitude)
+        }
+    }
+
+
+    override fun updateLongitude(longitude: String) {
+        _uiState.update {
+            it.copy(longitude = longitude)
+        }
+    }
+
+    override fun createActivity(): Task<Void> {
+        if (!validatePoints()) return Tasks.forException(Exception("Points should be a number between 0 and 100"))
+        if (uiState.value.name.isEmpty()) return Tasks.forException(Exception("Name should not be empty"))
+        if (uiState.value.description.isEmpty()) return Tasks.forException(Exception("Description should not be empty"))
+        if (!validateLatitude()) return Tasks.forException(Exception("Invalid latitude"))
+        if (!validateLongitude()) return Tasks.forException(Exception("Invalid longitude"))
+        if (!validateDateTime(uiState.value.startDateTime)) return Tasks.forException(Exception("Invalid start date time"))
+        if (!validateDateTime(uiState.value.endDateTime)) return Tasks.forException(Exception("Invalid end date time"))
+        if (!startDateTimeIsBeforeEndDateTime()) return Tasks.forException(Exception("Start date and time must be before end date and time"))
+        val eventInformation = mapOf(
+            "name" to uiState.value.name,
+            "description" to uiState.value.description,
+            "latitude" to uiState.value.latitude!!.toDouble(),
+            "longitude" to uiState.value.longitude!!.toDouble(),
+            "startDateTime" to uiState.value.startDateTime,
+            "endDateTime" to uiState.value.endDateTime,
+            "points" to uiState.value.pointsAwarded.toInt(),
+            "lateParticipationAllowed" to uiState.value.lateParticipationAllowed,
+        )
+        return _createEventModel.createEvent(eventInformation)
+    }
+
+    /**
+     * Sets the start date and time of the activity.
+     *
+     * @param year The year of the start date.
+     * @param month The month (0-11) of the start date.
+     * @param dayOfMonth The day of the month (1-31) of the start date.
+     * @param hour The hour (0-23) of the start time.
+     * @param minute The minute (0-59) of the start time.
+     */
+    fun setStartDateTime(year: Int, month: Int, dayOfMonth: Int, hour: Int, minute: Int) {
+        _uiState.update {
+            it.copy(
+                startYear = year,
+                startMonth = month,
+                startDayOfMonth = dayOfMonth,
+                startHour = hour,
+                startMinute = minute
+            )
+        }
+        refreshStartDateTimeText()
+    }
+
+    /**
+     * Sets the end date and time of the activity.
+     *
+     * @param year The year of the end date.
+     * @param month The month (0-11) of the end date.
+     * @param dayOfMonth The day of the month (1-31) of the end date.
+     * @param hour The hour (0-23) of the end time.
+     * @param minute The minute (0-59) of the end time.
+     */
+    fun setEndDateTime(year: Int, month: Int, dayOfMonth: Int, hour: Int, minute: Int) {
+        _uiState.update {
+            it.copy(
+                endYear = year,
+                endMonth = month,
+                endDayOfMonth = dayOfMonth,
+                endHour = hour,
+                endMinute = minute
+            )
+        }
+        refreshEndDateTimeText()
+    }
+
+    /**
+     * Refreshes the start date and time text displayed in the UI based on the current UI state.
+     * Uses the year, month, day of month, hour, and minute fields of the UI state to generate a formatted date string,
+     * and updates the startDateTime field of the UI state with the generated text.
+     */
+    private fun refreshStartDateTimeText() {
+        val y = uiState.value.startYear
+        val m = uiState.value.startMonth
+        val d = uiState.value.startDayOfMonth
+        val h = uiState.value.startHour
+        val min = uiState.value.startMinute
+
+        val dateText = String.format("%02d-%02d-%d %02d:%02d", d, m + 1, y, h, min)
+
+        _uiState.update {
+            it.copy(
+                startDateTime = dateText
+            )
+        }
+    }
+
+    /**
+     * Refreshes the end date and time text displayed in the UI based on the current UI state.
+     * Uses the year, month, day of month, hour, and minute fields of the UI state to generate a formatted date string,
+     * and updates the endDateTime field of the UI state with the generated text.
+     */
+    private fun refreshEndDateTimeText() {
+        val y = uiState.value.endYear
+        val m = uiState.value.endMonth
+        val d = uiState.value.endDayOfMonth
+        val h = uiState.value.endHour
+        val min = uiState.value.endMinute
+
+        val dateText = String.format("%02d-%02d-%d %02d:%02d", d, m + 1, y, h, min)
+        _uiState.update {
+            it.copy(
+                endDateTime = dateText
+            )
+        }
+    }
+
+
+    /**
+     * Updates the start date and time text displayed in the UI with the provided text.
+     *
+     * @param dateText The new text to display for the start date and time.
+     */
+    fun updateStartDateTimeText(dateText: String) {
+        _uiState.update { it.copy(startDateTime = dateText) }
+    }
+
+    /**
+     * Updates the end date and time text displayed in the UI with the provided text.
+     *
+     * @param dateText The new text to display for the end date and time.
+     */
+    fun updateEndDateTimeText(dateText: String) {
+        _uiState.update { it.copy(endDateTime = dateText) }
+    }
+
+    /**
+     * Updates the late participation allowed field of the UI state with the provided value.
+     * @param lateParticipationAllowed The new value for the late participation allowed field.
+     */
+    fun updateLateParticipationAllowed(lateParticipationAllowed: Boolean) {
+        _uiState.update {
+            it.copy(lateParticipationAllowed = lateParticipationAllowed)
+        }
+    }
+
+    /**
+     * Updates the points awarded field of the UI state with the provided value.
+     * @param pointsAwarded The new value for the points awarded field.
+     */
+    fun updatePointsAwarded(pointsAwarded: String) {
+        _uiState.update {
+            it.copy(pointsAwarded = pointsAwarded)
+        }
+    }
+
+
+    /**
+     * Validates the latitude value stored in the current UI state.
+     *
+     * @return True if the latitude value is valid and false otherwise.
+     */
+    private fun validateLatitude(): Boolean {
+        val latitude = uiState.value.latitude ?: return false
+
+        val latitudeDouble = latitude.toDoubleOrNull() ?: return false
+
+        if (latitudeDouble < EventViewModelConstants.MIN_LATITUDE || latitudeDouble > EventViewModelConstants.MAX_LATITUDE) return false
+
+        return true
+    }
+
+    /**
+     * Validates the longitude value stored in the current UI state.
+     *
+     * @return True if the longitude value is valid and false otherwise.
+     */
+    private fun validateLongitude(): Boolean {
+        val longitude = uiState.value.longitude ?: return false
+
+        val longitudeDouble = longitude.toDoubleOrNull() ?: return false
+
+        if (longitudeDouble < EventViewModelConstants.MIN_LONGITUDE || longitudeDouble > EventViewModelConstants.MAX_LONGITUDE) return false
+
+        return true
+    }
+
+    /**
+     * Validates the date and time string provided using the format specified by `EventViewModelConstants.DATE_TIME_FORMAT_REGEX`.
+     *
+     * @param dateTime The date and time string to validate.
+     *
+     * @return True if the date and time string is valid and false otherwise.
+     */
+    private fun validateDateTime(dateTime: String): Boolean {
+        val dateTimeRegex = Regex(EventViewModelConstants.DATE_TIME_FORMAT_REGEX)
+        val matchResult = dateTimeRegex.matchEntire(dateTime) ?: return false
+        val dateText = dateTime.slice(0..7)
+
+        try {
+            SimpleDateFormat("dd-mm-yyyy").parse(dateText)
+        } catch (pe: ParseException) {
+            return false
+        }
+        val year = matchResult.groupValues[3].toInt()
+        val month = matchResult.groupValues[2].toInt() - 1
+        val dayOfMonth = matchResult.groupValues[1].toInt()
+        val hour = matchResult.groupValues[4].toInt()
+        val minute = matchResult.groupValues[5].toInt()
+
+        if (year < 0) return false
+        if (month < 0 || month > 11) return false
+        if (dayOfMonth < 1 || dayOfMonth > 31) return false
+        if (hour < 0 || hour > 23) return false
+        if (minute < 0 || minute > 59) return false
+
+        return true
+    }
+
+
+    /**
+     * Checks if the start date/time is before the end date/time.
+     *
+     * @return true if the start date/time is before the end date/time, false otherwise
+     */
+    private fun startDateTimeIsBeforeEndDateTime(): Boolean {
+        val startMatchResult =
+            Regex(EventViewModelConstants.DATE_TIME_FORMAT_REGEX).matchEntire(uiState.value.startDateTime)
+                ?: return false
+        val endMatchResult =
+            Regex(EventViewModelConstants.DATE_TIME_FORMAT_REGEX).matchEntire(uiState.value.endDateTime)
+                ?: return false
+
+        val startYear = startMatchResult.groupValues[3].toInt()
+        val startMonth = startMatchResult.groupValues[2].toInt()
+        val startDayOfMonth = startMatchResult.groupValues[1].toInt()
+        val startHour = startMatchResult.groupValues[4].toInt()
+        val startMinute = startMatchResult.groupValues[5].toInt()
+
+        val endYear = endMatchResult.groupValues[3].toInt()
+        val endMonth = endMatchResult.groupValues[2].toInt()
+        val endDayOfMonth = endMatchResult.groupValues[1].toInt()
+        val endHour = endMatchResult.groupValues[4].toInt()
+        val endMinute = endMatchResult.groupValues[5].toInt()
+
+        val startCalendar = Calendar.getInstance()
+        startCalendar.set(startYear, startMonth, startDayOfMonth, startHour, startMinute)
+
+        val endCalendar = Calendar.getInstance()
+        endCalendar.set(endYear, endMonth, endDayOfMonth, endHour, endMinute)
+
+        return startCalendar.before(endCalendar)
+    }
+
+    /**
+     * Validates the points awarded value stored in the current UI state.
+     *
+     * @return True if the points awarded value is valid and false otherwise.
+     */
+    private fun validatePoints(): Boolean {
+        val pointsAwardedInt = uiState.value.pointsAwarded.toIntOrNull() ?: return false
+
+        if (pointsAwardedInt < EventViewModelConstants.MIN_POINTS || pointsAwardedInt > EventViewModelConstants.MAX_POINTS) return false
+
+        return true
+    }
+}

--- a/app/src/main/java/com/github/studydistractor/sdp/data/Event.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/data/Event.kt
@@ -12,6 +12,7 @@ package com.github.studydistractor.sdp.data
  * @property start time when the event starts
  * @property end time when the event ends
  * @property lateParticipation enable late participation (Can users join in the middle of the event)
+ * @property numberOfPoints number of points that the user can get by participating in the event
  * @property chatId id of the chat that is linked to the event
  */
 data class Event(
@@ -37,6 +38,7 @@ data class Event(
  * @property start time when the event starts
  * @property end time when the event ends
  * @property lateParticipation enable late participation (Can users join in the middle of the event)
+ * @property numberOfPoints number of points that the user can get by participating in the event
  * @property chatId id of the chat that is linked to the event
  */
 data class FirebaseEvent(
@@ -58,7 +60,7 @@ data class FirebaseEvent(
 }
 
 /**
- * represent participants of a particular events
+ * Represents participants of a particular event
  *
  * @property eventId id of the event
  * @property participants list of userId that participate in this event
@@ -69,10 +71,10 @@ data class EventParticipants(
 )
 
 /**
- * Represent a chat that is received or sent from/to the firebase database
+ * Represents participants of a particular event that is received or sent from/to the firebase database
  *
- * @param chatId id of the chat
- * @param messageIds list of messageId that were sent in the chat
+ * @param eventId id of the event
+ * @param participants list of userId that participate in this event
  */
 data class FirebaseEventParticipants(
     val eventId: String?,

--- a/app/src/main/java/com/github/studydistractor/sdp/data/Event.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/data/Event.kt
@@ -77,7 +77,7 @@ data class EventParticipants(
  * @param participants list of userId that participate in this event
  */
 data class FirebaseEventParticipants(
-    val eventId: String?,
+    val eventId: String? = null,
     val participants: List<String>? = null
 ) {
     fun toEventParticipants(): EventParticipants {

--- a/app/src/main/java/com/github/studydistractor/sdp/eventHistory/EventHistoryModel.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/eventHistory/EventHistoryModel.kt
@@ -1,0 +1,26 @@
+package com.github.studydistractor.sdp.eventHistory
+
+import com.github.studydistractor.sdp.data.Event
+import com.github.studydistractor.sdp.data.EventParticipants
+import com.google.android.gms.tasks.Task
+
+interface EventHistoryModel {
+
+    /**
+     * Observe the updates of the events and call the given function on the values
+     * @param onEventChange the function to call
+     */
+    fun observeEvents(onEventChange: (List<Event>) -> Unit)
+
+    /**
+     * Observe the updates of the eventParticipants and call the given function on the values
+     * @param onEventParticipantsChange the function to call
+     */
+    fun observeEventsParticipants(onEventParticipantsChange: (List<EventParticipants>) -> Unit)
+
+    /**
+     * Get the id of the current user
+     * @return a task containing the id if successful
+     */
+    fun getCurrentUid() : Task<String>
+}

--- a/app/src/main/java/com/github/studydistractor/sdp/eventHistory/EventHistoryServiceFirebase.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/eventHistory/EventHistoryServiceFirebase.kt
@@ -1,0 +1,111 @@
+package com.github.studydistractor.sdp.eventHistory
+
+import android.util.Log
+import androidx.compose.runtime.mutableStateListOf
+import com.github.studydistractor.sdp.data.Event
+import com.github.studydistractor.sdp.data.EventParticipants
+import com.github.studydistractor.sdp.data.FirebaseEvent
+import com.github.studydistractor.sdp.data.FirebaseEventParticipants
+import com.google.android.gms.tasks.Task
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.database.DataSnapshot
+import com.google.firebase.database.DatabaseError
+import com.google.firebase.database.DatabaseReference
+import com.google.firebase.database.FirebaseDatabase
+import com.google.firebase.database.ValueEventListener
+
+class EventHistoryServiceFirebase: EventHistoryModel {
+    private val eventPaths = "Events"
+    private val eventDatabaseRef: DatabaseReference =
+        FirebaseDatabase.getInstance().getReference(eventPaths)
+    private val eventParticipantsPaths = "EventParticipants"
+    private val eventParticipantsDatabaseRef: DatabaseReference =
+        FirebaseDatabase.getInstance().getReference(eventParticipantsPaths)
+    private var auth: FirebaseAuth = FirebaseAuth.getInstance()
+
+    private var onEventChange: (List<Event>) -> Unit = {}
+    private var onEventParticipantsChange: (List<EventParticipants>) -> Unit = {}
+
+    private val eventListener = object : ValueEventListener {
+        override fun onDataChange(snapshot: DataSnapshot) {
+            val firebaseEvents = mutableStateListOf<FirebaseEvent>()
+            for (event in snapshot.children) {
+                val eventItem = event.getValue(FirebaseEvent::class.java)
+                if (eventItem != null) {
+                    firebaseEvents.add(eventItem)
+                }
+            }
+
+            val events = mutableListOf<Event>()
+
+            for (fe in firebaseEvents) {
+                val ev: Event
+                try {
+                    ev = fe.toEvent()
+                } catch (e: Exception) {
+                    continue
+                }
+
+                events.add(ev)
+            }
+            onEventChange(events)
+        }
+
+        override fun onCancelled(error: DatabaseError) {
+            Log.d("Firebase Event", "loadPost:onCancelled " + error.toException().toString())
+        }
+    }
+
+    private val eventParticipantsListener = object : ValueEventListener {
+        override fun onDataChange(snapshot: DataSnapshot) {
+            val firebaseEventParticipants = mutableStateListOf<FirebaseEventParticipants>()
+            for (eP in snapshot.children) {
+                val eventParticipantsItem = eP.getValue(FirebaseEventParticipants::class.java)
+                if (eventParticipantsItem != null) {
+                    firebaseEventParticipants.add(eventParticipantsItem)
+                }
+            }
+
+            val eventsParticipants = mutableListOf<EventParticipants>()
+            for (fep in firebaseEventParticipants){
+                val ep : EventParticipants
+                try {
+                    ep = fep.toEventParticipants()
+                } catch(e: Exception){
+                    continue
+                }
+
+                eventsParticipants.add(ep)
+            }
+        }
+
+        override fun onCancelled(error: DatabaseError) {
+            Log.d("Firebase Event Participant", "loadPost:onCancelled " + error.toException().toString())
+        }
+    }
+
+    init {
+        eventDatabaseRef.addValueEventListener(eventListener)
+        eventParticipantsDatabaseRef.addValueEventListener(eventParticipantsListener)
+    }
+
+    override fun observeEvents(onEventChange: (List<Event>) -> Unit){
+        this.onEventChange = onEventChange
+    }
+
+    override fun observeEventsParticipants(onEventParticipantsChange: (List<EventParticipants>) -> Unit){
+        this.onEventParticipantsChange = onEventParticipantsChange
+    }
+
+    override fun getCurrentUid(): Task<String> {
+        val uid = auth.uid
+
+        if (uid.isNullOrEmpty()) {
+            Tasks.forException<Exception>(Exception("Empty or Null userId"))
+        }
+
+        return Tasks.forResult(uid)
+    }
+
+}

--- a/app/src/main/java/com/github/studydistractor/sdp/eventHistory/EventHistoryViewModel.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/eventHistory/EventHistoryViewModel.kt
@@ -1,0 +1,71 @@
+package com.github.studydistractor.sdp.eventHistory
+
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.lifecycle.ViewModel
+import com.github.studydistractor.sdp.data.Event
+import com.github.studydistractor.sdp.data.EventParticipants
+import com.github.studydistractor.sdp.ui.state.EventHistoryUiState
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import java.text.ParseException
+import java.text.SimpleDateFormat
+import java.util.Date
+
+class EventHistoryViewModel(
+    eventHistoryModel: EventHistoryModel
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(EventHistoryUiState())
+    private val _eventHistoryModel = eventHistoryModel
+    private var events : List<Event> = listOf()
+    private var eventParticipants: List<EventParticipants> = listOf()
+
+    val uiState: StateFlow<EventHistoryUiState> = _uiState.asStateFlow()
+
+    init {
+        _eventHistoryModel.observeEvents {
+            t -> events = t
+            refreshEventHistory()
+        }
+        _eventHistoryModel.observeEventsParticipants {
+            t -> eventParticipants = t
+            refreshEventHistory()
+        }
+
+    }
+
+    private fun eventIsFinished(event: Event): Boolean {
+        val formatter = SimpleDateFormat("dd-MM-yyyy HH:mm")
+        val date = Date()
+        val endDate : Date
+        try {
+            endDate = formatter.parse(event.end)
+        } catch (ep: ParseException) {
+            return false
+        }
+
+        return endDate.before(date)
+    }
+
+    fun refreshEventHistory(){
+        val uid = _eventHistoryModel.getCurrentUid().result
+        val usersEvent : SnapshotStateList<Event> = mutableStateListOf()
+
+        for (eP in eventParticipants){
+            if (eP.participants == null) continue
+            if (eP.participants.contains(uid)){
+                for (ev in events){
+                    if (ev.eventId == eP.eventId && eventIsFinished(ev)){
+                        usersEvent.add(ev)
+                    }
+                }
+            }
+        }
+
+        _uiState.update { EventHistoryUiState(usersEvent) }
+    }
+
+}

--- a/app/src/main/java/com/github/studydistractor/sdp/ui/AppBarTop.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/ui/AppBarTop.kt
@@ -1,10 +1,17 @@
 package com.github.studydistractor.sdp.ui
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.*
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextOverflow
@@ -18,8 +25,10 @@ fun AppBarTop(
     navigateUp: () -> Unit,
     goToMapActivity: () -> Unit,
     goToHistoryActivity: () -> Unit,
-    goToCreateDistractionActivity: () -> Unit
+    goToCreateDistractionActivity: () -> Unit,
+    goToCreateEventActivity: () -> Unit,
 ) {
+
     CenterAlignedTopAppBar(
         modifier = Modifier
             .testTag("app-bar-top"),
@@ -44,16 +53,33 @@ fun AppBarTop(
                         )
                     }
                 }
+                Box() {
+                    var dropDownExpanded by remember { mutableStateOf(false) }
+                    DropdownMenu(
+                        expanded = dropDownExpanded,
+                        onDismissRequest = { dropDownExpanded = false }
+                    ) {
+                        DropdownMenuItem({ Text("Create distraction") }, onClick = {
+                            dropDownExpanded = false
+                            goToCreateDistractionActivity()
+                        })
+                        DropdownMenuItem({ Text("Create event") }, onClick = {
+                            dropDownExpanded = false
+                            goToCreateEventActivity()
+                        })
+                    }
+                    IconButton(
+                        onClick = { dropDownExpanded = true },
+                        modifier = Modifier.testTag("app-bar-top__create-activity-button")
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.Add,
+                            contentDescription = "Create activity"
+                        )
+                    }
 
-                IconButton(
-                    onClick = goToCreateDistractionActivity,
-                    modifier = Modifier.testTag("app-bar-top__create-distraction-button")
-                ) {
-                    Icon(
-                        imageVector = Icons.Filled.Add,
-                        contentDescription = "Create distraction"
-                    )
                 }
+
             }
         },
         actions = {

--- a/app/src/main/java/com/github/studydistractor/sdp/ui/CreateDistractionScreen.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/ui/CreateDistractionScreen.kt
@@ -1,31 +1,28 @@
 package com.github.studydistractor.sdp.ui
 
-import android.content.Context
-import android.widget.Toast
 import androidx.compose.foundation.layout.*
-import androidx.compose.material3.Button
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.github.studydistractor.sdp.createDistraction.CreateDistractionViewModel
+import com.github.studydistractor.sdp.ui.components.CreateActivityButton
+import com.github.studydistractor.sdp.ui.components.CreateActivityNameAndDescriptionFields
+import com.github.studydistractor.sdp.ui.components.CreateLatitudeAndLongitudeFields
 
-object DistractionScreenConstants {
-    const val MAX_NAME_LENGTH = 20
-    const val MAX_DESCRIPTION_LENGTH = 200
-}
+
 /**
  * Screen to create distraction
  *
- * @param distractionModel distraction service where to add the distraction
+ * @param createDistractionViewModel distraction service where to add the distraction
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -33,70 +30,64 @@ fun CreateDistractionScreen(
     createDistractionViewModel: CreateDistractionViewModel,
     onDistractionCreated: () -> Unit
 ) {
-    fun showFailureToast(context: Context, message: String) {
-        Toast.makeText(context, "Failure: $message", Toast.LENGTH_SHORT)
-            .show()
-    }
-
-    val uiState by createDistractionViewModel.uiState.collectAsState()
-    val context = LocalContext.current
-
+    val uiState = createDistractionViewModel.uiState.collectAsState().value
     Box(
         modifier = Modifier
             .padding(16.dp)
-            .testTag("create-distraction-screen__main-container")
+            .testTag("create-activity-screen__main-container")
     ) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(16.dp),
+                .padding(16.dp)
+                .verticalScroll(rememberScrollState()),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center
         ) {
-            OutlinedTextField(
-                value = uiState.name,
-                label = {Text("name")},
-                onValueChange = { createDistractionViewModel.updateName(it) },
-                modifier = Modifier
-                    .testTag("name")
-                    .fillMaxWidth(),
-                supportingText = {
-                    Text(
-                        text = uiState.supportingTextName,
-                        modifier = Modifier.fillMaxWidth()
-                            .testTag("nameSupport"),
-                        textAlign = TextAlign.End,
-                    )
-                },
-            )
-
-            OutlinedTextField(
-                value = uiState.description,
-                label = {Text("description")},
-                onValueChange = { createDistractionViewModel.updateDescription(it) },
-                modifier = Modifier
-                    .testTag("description")
-                    .fillMaxWidth(),
-                supportingText = {
-                    Text(
-                        text = uiState.supportingTextDescription,
-                        modifier = Modifier.fillMaxWidth()
-                            .testTag("descriptionSupport"),
-                        textAlign = TextAlign.End
-                    )
-                },
-            )
-
-            Button(
-                onClick = {
-                    createDistractionViewModel.createDistraction()
-                        .addOnSuccessListener { onDistractionCreated() }
-                        .addOnFailureListener { showFailureToast(context, it.message.orEmpty()) }
-                },
-                modifier = Modifier.testTag("addActivity")
-            ) {
-                Text("Create new distraction")
+            Row {
+                androidx.compose.material.Text(
+                    text = "Create distraction",
+                    style = MaterialTheme.typography.titleLarge,
+                    modifier = Modifier
+                        .padding(vertical = 32.dp)
+                        .testTag("create-distraction-screen__title")
+                )
             }
+            CreateActivityNameAndDescriptionFields(
+                createActivityViewModel = createDistractionViewModel
+            )
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag("locationRow"),
+                horizontalArrangement = Arrangement.Start,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+
+                Checkbox(
+                    checked = uiState.locationFieldIsVisible,
+                    modifier = Modifier.testTag("checkbox"),
+                    onCheckedChange = {
+                        createDistractionViewModel.updateLocationFieldIsVisible(it)
+                    }
+                )
+                Text(text = "Add location to activity")
+            }
+
+            if (uiState.locationFieldIsVisible) {
+                CreateLatitudeAndLongitudeFields(createActivityViewModel = createDistractionViewModel)
+            } else {
+                createDistractionViewModel.updateLatitude("")
+                createDistractionViewModel.updateLongitude("")
+            }
+
+
+            CreateActivityButton(
+                createActivityViewModel = createDistractionViewModel,
+                onActivityCreated = onDistractionCreated,
+                buttonText = "Create new distraction"
+            )
         }
     }
 }

--- a/app/src/main/java/com/github/studydistractor/sdp/ui/CreateEventScreen.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/ui/CreateEventScreen.kt
@@ -1,0 +1,284 @@
+package com.github.studydistractor.sdp.ui
+
+import android.app.DatePickerDialog
+import android.app.TimePickerDialog
+import android.content.Context
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CalendarMonth
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import androidx.compose.material3.*
+import com.github.studydistractor.sdp.createEvent.CreateEventViewModel
+import com.github.studydistractor.sdp.ui.components.CreateActivityButton
+import com.github.studydistractor.sdp.ui.components.CreateActivityNameAndDescriptionFields
+import com.github.studydistractor.sdp.ui.components.CreateLatitudeAndLongitudeFields
+import com.github.studydistractor.sdp.ui.state.CreateEventUiState
+
+
+
+/**
+ * Screen to create a new event
+ *
+ * @param createEventViewModel ViewModel for this screen
+ * @param onEventCreated Callback to be called when event is created
+ */
+@Composable
+fun CreateEventScreen(
+    createEventViewModel: CreateEventViewModel,
+    onEventCreated: () -> Unit
+) {
+    val uiState by createEventViewModel.uiState.collectAsState()
+    val context = LocalContext.current
+    val startDateTimePicker = dateTimePickerDialog(
+        context,
+        { y, m, d, h, min -> createEventViewModel.setStartDateTime(y, m, d, h, min) },
+        uiState.startYear,
+        uiState.startMonth,
+        uiState.startDayOfMonth,
+        uiState.startHour,
+        uiState.startMinute
+    )
+    val endDateTimePicker = dateTimePickerDialog(
+        context,
+        { y, m, d, h, min -> createEventViewModel.setEndDateTime(y, m, d, h, min) },
+        uiState.endYear,
+        uiState.endMonth,
+        uiState.endDayOfMonth,
+        uiState.endHour,
+        uiState.endMinute
+    )
+
+
+
+    Box(
+        modifier = Modifier
+            .padding(16.dp)
+            .testTag("create-activity-screen__main-container")
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp)
+                .verticalScroll(rememberScrollState())
+                .testTag("create-event-screen__column"),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+
+            Row {
+                androidx.compose.material.Text(
+                    text = "Create event",
+                    style = MaterialTheme.typography.titleLarge,
+                    modifier = Modifier
+                        .padding(vertical = 32.dp)
+                        .testTag("create-event-screen__title")
+                )
+            }
+
+            CreateActivityNameAndDescriptionFields(
+                createActivityViewModel = createEventViewModel
+            )
+
+            CreateDateTimeField(
+                valueText = uiState.startDateTime,
+                onValueChange = { createEventViewModel.updateStartDateTimeText(it) },
+                labelText = "Start date and time (dd-mm-yyyy hh:mm)",
+                onClickButton = { startDateTimePicker.show() }
+            )
+
+            CreateDateTimeField(
+                valueText = uiState.endDateTime,
+                onValueChange = { createEventViewModel.updateEndDateTimeText(it) },
+                labelText = "End date and time (dd-mm-yyyy hh:mm)",
+                onClickButton = { endDateTimePicker.show() }
+            )
+
+            CreateLatitudeAndLongitudeFields(
+                createActivityViewModel = createEventViewModel
+            )
+
+            PointsAwardedField(createActivityViewModel = createEventViewModel)
+            LateParticipationCheckbox(
+                createEventViewModel = createEventViewModel
+            )
+
+            CreateActivityButton(
+                createActivityViewModel = createEventViewModel,
+                onActivityCreated = onEventCreated,
+                buttonText = "Create event"
+            )
+        }
+    }
+}
+
+/**
+ * Creates a date picker dialog
+ * @param context Context
+ * @param setDateTime Callback to be called when date and time is set
+ * @param year Year
+ * @param month Month
+ * @param dayOfMonth Day of month
+ * @param hour Hour
+ * @param minute Minute
+ * @return DatePickerDialog
+ */
+private fun dateTimePickerDialog(
+    context: Context,
+    setDateTime: (year: Int, month: Int, day: Int, h: Int, m: Int) -> Unit,
+    year: Int,
+    month: Int,
+    dayOfMonth: Int,
+    hour: Int,
+    minute: Int
+): DatePickerDialog {
+    return DatePickerDialog(
+        context,
+        { _, y, m, d ->
+            val timePicker = TimePickerDialog(
+                context,
+                { _, h, min -> setDateTime(y, m, d, h, min) },
+                hour,
+                minute,
+                true
+            )
+            timePicker.show()
+        },
+        year,
+        month,
+        dayOfMonth
+    )
+}
+
+/**
+ * Creates a text field to allow user to enter date and time
+ * @param valueText Text to be displayed in the text field
+ * @param onValueChange Callback to be called when text is changed
+ * @param labelText Label text
+ * @param onClickButton Callback to be called when button is clicked
+ * @return TextField
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CreateDateTimeField(
+    valueText: String,
+    onValueChange: (String) -> Unit,
+    labelText: String,
+    onClickButton: () -> Unit,
+) {
+    OutlinedTextField(
+        value = valueText,
+        onValueChange = { onValueChange(it) },
+        label = { Text(labelText) },
+        trailingIcon = {
+            Button(
+                onClick = { onClickButton() },
+                colors = ButtonDefaults.buttonColors(contentColor = Color.White),
+                modifier = Modifier
+                    .testTag(labelText + "Button")
+                    .padding(8.dp),
+                shape = MaterialTheme.shapes.small,
+            ) {
+                Icon(Icons.Filled.CalendarMonth, contentDescription = null)
+            }
+        },
+        singleLine = true,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp)
+            .testTag(labelText + "Field")
+    )
+}
+
+/**
+ * Creates a checkbox to allow user to select if late participation is allowed
+ * @param createEventViewModel ViewModel
+ * @return Row
+ */
+@Composable
+fun LateParticipationCheckbox(
+    createEventViewModel: CreateEventViewModel
+) {
+    val uiState by createEventViewModel.uiState.collectAsState()
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag("checkBoxRow"),
+        horizontalArrangement = Arrangement.Start,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Checkbox(
+            checked = uiState.lateParticipationAllowed,
+            onCheckedChange = { createEventViewModel.updateLateParticipationAllowed(it) },
+            modifier = Modifier
+                .testTag("lateParticipationAllowedCheckbox")
+        )
+        Text(
+            text = "Allow late participation to this event",
+            modifier = Modifier
+                .testTag("lateParticipationAllowedText")
+                .padding(8.dp)
+        )
+    }
+}
+
+/**
+ * Creates a text field to allow user to enter points awarded by the event
+ * @param createActivityViewModel ViewModel
+ * @param uiState UI state
+ * @return Row
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PointsAwardedField(
+    createActivityViewModel: CreateEventViewModel
+) {
+    val uiState by createActivityViewModel.uiState.collectAsState()
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag("pointsAwardedRow")
+            .padding(8.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = "This event awards",
+            modifier = Modifier
+                .testTag("pointsAwardedText")
+                .padding(8.dp)
+        )
+        OutlinedTextField(
+            value = uiState.pointsAwarded,
+            onValueChange = { createActivityViewModel.updatePointsAwarded(it) },
+            singleLine = true,
+            modifier = Modifier
+                .padding(vertical = 2.dp)
+                .testTag("pointsAwardedField")
+                .weight(1f)
+        )
+        Text(
+            text = " points.",
+            modifier = Modifier
+                .testTag("pointsAwardedValueText")
+                .padding(8.dp)
+        )
+    }
+
+}

--- a/app/src/main/java/com/github/studydistractor/sdp/ui/EventHistoryScreen.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/ui/EventHistoryScreen.kt
@@ -1,0 +1,53 @@
+package com.github.studydistractor.sdp.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Text
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import com.github.studydistractor.sdp.eventChat.EventChatViewModel
+import com.github.studydistractor.sdp.eventHistory.EventHistoryViewModel
+import com.github.studydistractor.sdp.ui.components.EventHistoryCard
+
+/**
+ * Screen representing the history of the event that are finished and in which the current user has
+ * taken part
+ * @param eventHistoryViewModel the view model
+ * @param chatViewModel the chat view model. It is useful when clicking on the button to see the
+ * chat of an event
+ * @param onChatButtonClicked the function to perform when the user click on the chat button of an
+ * event
+ */
+@Composable
+fun EventHistoryScreen(
+    eventHistoryViewModel: EventHistoryViewModel,
+    chatViewModel: EventChatViewModel,
+    onChatButtonClicked: () -> Unit
+){
+    val uiState by eventHistoryViewModel.uiState.collectAsState()
+
+    Column(
+        modifier = Modifier.padding(6.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ){
+        Text("Your event history",
+            modifier = Modifier
+                .padding(vertical = 32.dp)
+                .testTag("event-history-screen__title"),
+            style = MaterialTheme.typography.titleLarge,
+        )
+        LazyColumn(){
+            items(uiState.eventHistory) {i->
+                EventHistoryCard(i, chatViewModel, onChatButtonClicked)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/github/studydistractor/sdp/ui/components/CreateActivityButton.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/ui/components/CreateActivityButton.kt
@@ -1,0 +1,29 @@
+package com.github.studydistractor.sdp.ui.components
+
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import com.github.studydistractor.sdp.createActivity.CreateActivityViewModel
+
+
+@Composable
+fun CreateActivityButton(
+    createActivityViewModel: CreateActivityViewModel,
+    onActivityCreated: () -> Unit,
+    buttonText: String
+) {
+    val context = LocalContext.current
+    Button(
+        onClick = {
+            createActivityViewModel.createActivity()
+                .addOnSuccessListener { onActivityCreated() }
+                .addOnFailureListener { showFailureToast(context, it.message.orEmpty()) }
+        },
+        modifier = Modifier.testTag("addActivity")
+    ) {
+        Text(buttonText)
+    }
+}

--- a/app/src/main/java/com/github/studydistractor/sdp/ui/components/CreateActivityScreen.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/ui/components/CreateActivityScreen.kt
@@ -1,0 +1,79 @@
+package com.github.studydistractor.sdp.ui.components
+
+import android.content.Context
+import android.widget.Toast
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.github.studydistractor.sdp.createActivity.CreateActivityViewModel
+import com.github.studydistractor.sdp.ui.state.CreateActivityUiState
+
+
+/**
+ * Screen to create activity (event/distraction)
+ *
+ * @param createActivityViewModel the activity service where to add the activity
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CreateActivityNameAndDescriptionFields(
+    createActivityViewModel: CreateActivityViewModel
+) {
+
+
+    val uiState by createActivityViewModel.uiState.collectAsState()
+
+
+    OutlinedTextField(
+        value = uiState.name,
+        label = { Text("name") },
+        onValueChange = { createActivityViewModel.updateName(it) },
+        modifier = Modifier
+            .testTag("name")
+            .fillMaxWidth(),
+        supportingText = {
+            Text(
+                text = uiState.supportingTextName,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag("nameSupport"),
+                textAlign = TextAlign.End,
+            )
+        },
+    )
+
+    OutlinedTextField(
+        value = uiState.description,
+        label = { Text("description") },
+        onValueChange = { createActivityViewModel.updateDescription(it) },
+        modifier = Modifier
+            .testTag("description")
+            .fillMaxWidth(),
+        supportingText = {
+            Text(
+                text = uiState.supportingTextDescription,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag("descriptionSupport"),
+                textAlign = TextAlign.End
+            )
+        },
+    )
+
+
+}
+
+fun showFailureToast(context: Context, message: String) {
+    Toast.makeText(context, "Failure: $message", Toast.LENGTH_SHORT)
+        .show()
+}

--- a/app/src/main/java/com/github/studydistractor/sdp/ui/components/CreateLatitudeAndLongitudeFields.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/ui/components/CreateLatitudeAndLongitudeFields.kt
@@ -1,0 +1,41 @@
+package com.github.studydistractor.sdp.ui.components
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import com.github.studydistractor.sdp.createActivity.CreateActivityViewModel
+
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CreateLatitudeAndLongitudeFields(
+    createActivityViewModel: CreateActivityViewModel,
+) {
+    val uiState by createActivityViewModel.uiState.collectAsState()
+    OutlinedTextField(
+        value = uiState.latitude.orEmpty(),
+        label = { Text("latitude") },
+        onValueChange = { createActivityViewModel.updateLatitude(it) },
+        modifier = Modifier
+            .testTag("latitude")
+            .fillMaxWidth()
+            .padding(top = 16.dp),
+    )
+    OutlinedTextField(
+        value = uiState.longitude.orEmpty(),
+        label = { Text("longitude") },
+        onValueChange = { createActivityViewModel.updateLongitude(it) },
+        modifier = Modifier
+            .testTag("longitude")
+            .fillMaxWidth()
+            .padding(top = 16.dp),
+    )
+}

--- a/app/src/main/java/com/github/studydistractor/sdp/ui/components/EventHistoryCard.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/ui/components/EventHistoryCard.kt
@@ -1,0 +1,83 @@
+package com.github.studydistractor.sdp.ui.components
+
+import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.Button
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import com.github.studydistractor.sdp.data.Event
+import com.github.studydistractor.sdp.eventChat.EventChatViewModel
+
+/**
+ * The function representing an event in the history of events
+ */
+@Composable
+fun EventHistoryCard(
+    event: Event,
+    chatViewModel: EventChatViewModel,
+    onChatClicked: () -> Unit
+){
+
+    Row(modifier = Modifier.padding(all = 8.dp)) {
+        var isExpanded by remember { mutableStateOf(false) }
+
+        Column(
+            modifier = Modifier
+                .clickable { isExpanded = !isExpanded }
+                .testTag("event-history-card__title " + event.eventId)
+
+        ) {
+            Text(
+                text = event.name,
+                color = MaterialTheme.colorScheme.secondary,
+                style = MaterialTheme.typography.titleMedium,
+            )
+            Text(
+                text = "Started on ${event.start} / Ended on ${event.end}",
+                color = MaterialTheme.colorScheme.primary,
+                style = MaterialTheme.typography.titleMedium,
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+
+            Surface(
+                shape = MaterialTheme.shapes.medium,
+                modifier = Modifier
+                    .animateContentSize()
+                    .padding(1.dp),
+            ) {
+                Text(
+                    text = event.description,
+                    modifier = Modifier.padding(all = 4.dp),
+                    maxLines = if(isExpanded) Int.MAX_VALUE else 1,
+                    style = MaterialTheme.typography.bodySmall
+                )
+            }
+
+            Button(
+                onClick = {
+                    chatViewModel.changeEventChat(event.eventId!!)
+                    onChatClicked()
+                },
+            ) {
+                Text(
+                    "See Chat",
+                )
+            }
+        }
+    }
+
+}

--- a/app/src/main/java/com/github/studydistractor/sdp/ui/state/CreateActivityUiState.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/ui/state/CreateActivityUiState.kt
@@ -1,0 +1,10 @@
+package com.github.studydistractor.sdp.ui.state
+
+interface CreateActivityUiState {
+    val name: String
+    val description: String
+    val supportingTextName: String
+    val supportingTextDescription: String
+    val latitude: String?
+    val longitude: String?
+}

--- a/app/src/main/java/com/github/studydistractor/sdp/ui/state/CreateDistractionUiState.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/ui/state/CreateDistractionUiState.kt
@@ -1,8 +1,11 @@
 package com.github.studydistractor.sdp.ui.state
 
-data class CreateDistractionUiState(
-    val name: String = "",
-    val description: String = "",
-    val supportingTextName: String = "",
-    val supportingTextDescription: String = "",
-)
+data class CreateDistractionUiState  (
+    override val name: String = "",
+    override val description: String = "",
+    override val supportingTextName: String = "",
+    override val supportingTextDescription: String = "",
+    override val latitude: String? = null,
+    override val longitude: String? = null,
+    val locationFieldIsVisible: Boolean = false,
+) : CreateActivityUiState

--- a/app/src/main/java/com/github/studydistractor/sdp/ui/state/CreateEventUiState.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/ui/state/CreateEventUiState.kt
@@ -1,0 +1,24 @@
+package com.github.studydistractor.sdp.ui.state
+
+data class CreateEventUiState (
+    override val name: String = "",
+    override val description: String = "",
+    override val supportingTextName: String = "",
+    override val supportingTextDescription: String = "",
+    val startDateTime: String = "",
+    val endDateTime: String = "",
+    val startYear: Int = 2023,
+    val startMonth: Int = 4,
+    val startDayOfMonth: Int = 1,
+    val startHour: Int = 0,
+    val startMinute: Int = 0,
+    val endYear: Int = 2023,
+    val endMonth: Int = 4,
+    val endDayOfMonth: Int = 1,
+    val endHour: Int = 0,
+    val endMinute: Int = 0,
+    val lateParticipationAllowed: Boolean = false,
+    override val latitude: String? = null,
+    override val longitude: String? = null,
+    val pointsAwarded: String = "",
+) : CreateActivityUiState

--- a/app/src/main/java/com/github/studydistractor/sdp/ui/state/EventHistoryUiState.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/ui/state/EventHistoryUiState.kt
@@ -1,0 +1,8 @@
+package com.github.studydistractor.sdp.ui.state
+
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import com.github.studydistractor.sdp.data.Event
+
+data class EventHistoryUiState(
+    val eventHistory: SnapshotStateList<Event> = SnapshotStateList()
+)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,4 +15,6 @@
     <string name="screen_name_create_user">CreateUser</string>
     <string name="screen_name_daily_challenge">Daily Challenge</string>
     <string name="screen_name_chat_event">Chat event</string>
+    <string name="screen_name_event_history">Event History</string>
+    <string name="screen_name_create_event">CreateEvent</string>
 </resources>


### PR DESCRIPTION
Closes #137  and #102 . Clicking on the plus sign on the top bar  opens a pop up that allows the user to select between creating a distraction and creating an event.

![image](https://github.com/StudyDistractor/sdp/assets/24369350/882d10bd-ef46-4474-8f9b-9d083356469e)
![image](https://github.com/StudyDistractor/sdp/assets/24369350/9287538e-9f33-44af-b434-8fda1adac80e)
