### PR TITLE
feat(#145): User can claim points once the event finished

### DIFF
--- a/app/src/androidTest/java/com/github/studydistractor/sdp/fakeServices/EventHistoryServiceFake.kt
+++ b/app/src/androidTest/java/com/github/studydistractor/sdp/fakeServices/EventHistoryServiceFake.kt
@@ -1,119 +1,155 @@
 package com.github.studydistractor.sdp.fakeServices
 
 import com.github.studydistractor.sdp.data.Event
+import com.github.studydistractor.sdp.data.EventClaimPoints
 import com.github.studydistractor.sdp.data.EventParticipants
+import com.github.studydistractor.sdp.data.UserData
 import com.github.studydistractor.sdp.eventHistory.EventHistoryModel
 import com.google.android.gms.tasks.Task
 import com.google.android.gms.tasks.Tasks
 
 class EventHistoryServiceFake: EventHistoryModel {
-    private fun getEvents(): Task<List<Event>> {
-        return Tasks.forResult(
-            listOf(
-                Event(
-                    "event1",
-                    "event1",
-                    "event1",
-                    1.0,
-                    1.0,
-                    "10-10-1997 00:00",
-                    "11-11-1997 00:00",
-                    false,
-                    0,
-                    "chatId1"
-                ),
-                Event(
-                    "event2",
-                    "event2",
-                    "event2",
-                    2.0,
-                    2.0,
-                    "10-10-1998 00:00",
-                    "11-11-1998 00:00",
-                    false,
-                    0,
-                    "chatId2"
-                ),
-                Event(
-                    "event3",
-                    "event3",
-                    "event3",
-                    3.0,
-                    3.0,
-                    "10-10-1999 00:00",
-                    "11-11-1999 00:00",
-                    false,
-                    0,
-                    "chatId3"
-                ),
-                Event(
-                    "NotFinishedEvent",
-                    "NotFinishedEvent",
-                    "NotFinishedEvent",
-                    3.0,
-                    3.0,
-                    "10-10-1999 00:00",
-                    "10-10-2050 00:00",
-                    false,
-                    0,
-                    "NotFinishedEvent"
-                ),
-                Event(
-                    "UserHasNotTakenPartIn",
-                    "UserHasNotTakenPartIn",
-                    "UserHasNotTakenPartIn",
-                    3.0,
-                    3.0,
-                    "10-10-1999 00:00",
-                    "10-10-2000 00:00",
-                    false,
-                    0,
-                    "UserHasNotTakenPartIn"
-                )
-            )
-        )
-    }
 
-    private fun getEventParticipants(): Task<List<EventParticipants>> {
-        return Tasks.forResult(
-            listOf(
-                EventParticipants(
-                    "event1",
-                    listOf("userId", "Joe", "Billy")
-                ),
-                EventParticipants(
-                    "event2",
-                    listOf("userId", "Joe", "Max", "Billy")
-                ),
-                EventParticipants(
-                    "event3",
-                    listOf("userId", "Daniel")
-                ),
-                EventParticipants(
-                    "NotFinishedEvent",
-                    listOf("userId", "Kevin", "Nelson")
-                ),
-                EventParticipants(
-                    "UserHasNotTakenPartIn",
-                    listOf("Athena", "Adrien", "Yohan", "Willy", "Orélian")
-                )
-            )
+    val events = mutableListOf(
+        Event(
+            "event1",
+            "event1",
+            "event1",
+            1.0,
+            1.0,
+            "10-10-1997 00:00",
+            "11-11-1997 00:00",
+            false,
+            1,
+            "chatId1"
+        ),
+        Event(
+            "event2",
+            "event2",
+            "event2",
+            2.0,
+            2.0,
+            "10-10-1998 00:00",
+            "11-11-1998 00:00",
+            false,
+            2,
+            "chatId2"
+        ),
+        Event(
+            "event3",
+            "event3",
+            "event3",
+            3.0,
+            3.0,
+            "10-10-1999 00:00",
+            "11-11-1999 00:00",
+            false,
+            3,
+            "chatId3"
+        ),
+        Event(
+            "NotFinishedEvent",
+            "NotFinishedEvent",
+            "NotFinishedEvent",
+            3.0,
+            3.0,
+            "10-10-1999 00:00",
+            "10-10-2050 00:00",
+            false,
+            4,
+            "NotFinishedEvent"
+        ),
+        Event(
+            "UserHasNotTakenPartIn",
+            "UserHasNotTakenPartIn",
+            "UserHasNotTakenPartIn",
+            3.0,
+            3.0,
+            "10-10-1999 00:00",
+            "10-10-2000 00:00",
+            false,
+            5,
+            "UserHasNotTakenPartIn"
         )
-    }
+    )
+
+    val eventParticipants = mutableListOf(
+        EventParticipants(
+            "event1",
+            listOf("userId", "Joe", "Billy")
+        ),
+        EventParticipants(
+            "event2",
+            listOf("userId", "Joe", "Max", "Billy")
+        ),
+        EventParticipants(
+            "event3",
+            listOf("userId", "Daniel")
+        ),
+        EventParticipants(
+            "NotFinishedEvent",
+            listOf("userId", "Kevin", "Nelson")
+        ),
+        EventParticipants(
+            "UserHasNotTakenPartIn",
+            listOf("Athena", "Adrien", "Yohan", "Willy", "Orélian")
+        )
+    )
+
+    val eventClaimPoints = mutableListOf(
+        EventClaimPoints(
+            "event1",
+            listOf("Joe", "Billy")
+        ),
+        EventClaimPoints(
+            "event2",
+            listOf("userId", "Joe", "Billy")
+        ),
+    )
+
+    var currentUser =
+        UserData(
+            "userId",
+            "userId",
+            "userId",
+            "+41000000000",
+        12,
+            0
+        )
+
+
+
 
     override fun observeEvents(onEventChange: (List<Event>) -> Unit) {
-        getEvents().continueWith {
-            t -> onEventChange(t.result)
-        }
+        onEventChange(events)
     }
 
     override fun observeEventsParticipants(onEventParticipantsChange: (List<EventParticipants>) -> Unit) {
-        getEventParticipants().continueWith {
-                t -> onEventParticipantsChange(t.result)
-        }
+        onEventParticipantsChange(eventParticipants)
     }
 
-    override fun getCurrentUid(): Task<String> {
-        return Tasks.forResult("userId")
+    override fun observeEventClaimPoints(onEventClaimPointsChange: (List<EventClaimPoints>) -> Unit) {
+        onEventClaimPointsChange(eventClaimPoints)
     }
+
+    override fun observeCurrentUser(onCurrentUserChange: (UserData) -> Unit) {
+        onCurrentUserChange(currentUser)
+    }
+
+    override fun postUser(userData: UserData): Task<Void> {
+        currentUser = userData
+        return Tasks.forResult(null)
+    }
+
+    override fun postEventClaimPoints(eventClaimPoints: EventClaimPoints): Task<Void> {
+        for (ecp in this.eventClaimPoints){
+            if (ecp.eventId == eventClaimPoints.eventId){
+                return Tasks.forResult(null)
+            }
+        }
+
+        this.eventClaimPoints.add(eventClaimPoints)
+        return Tasks.forResult(null)
+    }
+
 }

--- a/app/src/androidTest/java/com/github/studydistractor/sdp/ui/EventHistoryScreenTest.kt
+++ b/app/src/androidTest/java/com/github/studydistractor/sdp/ui/EventHistoryScreenTest.kt
@@ -15,9 +15,13 @@ import com.github.studydistractor.sdp.eventHistory.EventHistoryViewModel
 import com.github.studydistractor.sdp.fakeServices.CreateUserServiceFake
 import com.github.studydistractor.sdp.fakeServices.EventChatServiceFake
 import com.github.studydistractor.sdp.fakeServices.EventHistoryServiceFake
+import com.google.android.gms.tasks.Tasks
+import org.junit.Assert
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.TimeUnit
 
 class EventHistoryScreenTest {
     @get:Rule(order = 1)
@@ -59,6 +63,54 @@ class EventHistoryScreenTest {
         composeRule.onNodeWithTag("event-history-card__title NotFinishedEvent").assertDoesNotExist()
         composeRule.onNodeWithTag("event-history-card__title UserHasNotTakenPartIn").assertDoesNotExist()
     }
+}
+
+class EventHistoryViewModelTest{
+    val eventHistoryServiceFake = EventHistoryServiceFake()
+    val eventHistoryViewModel = EventHistoryViewModel(eventHistoryModel = eventHistoryServiceFake)
+
+    @Test
+    fun testEmptyEvent(){
+        Assert.assertThrows(ExecutionException::class.java) {
+            Tasks.await( eventHistoryViewModel.claimPoints(""), 100, TimeUnit.MILLISECONDS)
+        }
+    }
+
+    @Test
+    fun testNoneExistingEvent(){
+        Assert.assertThrows(ExecutionException::class.java) {
+            Tasks.await( eventHistoryViewModel.claimPoints("event4"), 100, TimeUnit.MILLISECONDS)
+        }
+    }
+
+    @Test
+    fun testAlreadyClaimedPoint(){
+        Assert.assertThrows(ExecutionException::class.java) {
+            Tasks.await( eventHistoryViewModel.claimPoints("event2"), 100, TimeUnit.MILLISECONDS)
+        }
+    }
+
+    @Test
+    fun testUnClaimedPointWithExistingEventClaimPoint(){
+        val old_size = eventHistoryServiceFake.eventClaimPoints.size
+        // If it throws an exception then it should stop the test
+        Tasks.await( eventHistoryViewModel.claimPoints("event1"), 100, TimeUnit.MILLISECONDS)
+
+        Assert.assertEquals(1, eventHistoryServiceFake.currentUser.score)
+        Assert.assertEquals(old_size, eventHistoryServiceFake.eventClaimPoints.size)
+    }
+
+    @Test
+    fun testUnClaimedPointWithNonExistingEventClaimPoint(){
+        val old_size = eventHistoryServiceFake.eventClaimPoints.size
+        // If it throws an exception then it should stop the test
+        Tasks.await( eventHistoryViewModel.claimPoints("event3"), 100, TimeUnit.MILLISECONDS)
+
+        Assert.assertEquals(3,eventHistoryServiceFake.currentUser.score)
+        Assert.assertEquals(old_size+ 1, eventHistoryServiceFake.eventClaimPoints.size)
+    }
+
+
 
     @Test
     fun testChatButtonIsDisplayed(){

--- a/app/src/androidTest/java/com/github/studydistractor/sdp/ui/EventHistoryScreenTest.kt
+++ b/app/src/androidTest/java/com/github/studydistractor/sdp/ui/EventHistoryScreenTest.kt
@@ -87,17 +87,17 @@ class EventHistoryScreenTest {
         composeRule.onNodeWithTag("event-history-card__points-button event1").assertExists()
         composeRule.onNodeWithTag("event-history-card__points-button event1").assertIsDisplayed()
         composeRule.onNodeWithTag("event-history-card__points-button event1").assertHasClickAction()
-        composeRule.onNodeWithTag("event-history-card__points-button event1").assert(hasText("See Points"))
+        composeRule.onNodeWithTag("event-history-card__points-button event1").assert(hasText("Claim Points"))
 
         composeRule.onNodeWithTag("event-history-card__points-button event2").assertExists()
         composeRule.onNodeWithTag("event-history-card__points-button event2").assertIsDisplayed()
         composeRule.onNodeWithTag("event-history-card__points-button event2").assertHasClickAction()
-        composeRule.onNodeWithTag("event-history-card__points-button event2").assert(hasText("See Points"))
+        composeRule.onNodeWithTag("event-history-card__points-button event2").assert(hasText("Claim Points"))
 
         composeRule.onNodeWithTag("event-history-card__points-button event3").assertExists()
         composeRule.onNodeWithTag("event-history-card__points-button event3").assertIsDisplayed()
         composeRule.onNodeWithTag("event-history-card__points-button event3").assertHasClickAction()
-        composeRule.onNodeWithTag("event-history-card__points-button event3").assert(hasText("See Points"))
+        composeRule.onNodeWithTag("event-history-card__points-button event3").assert(hasText("Claim Points"))
     }
 
     @Test

--- a/app/src/androidTest/java/com/github/studydistractor/sdp/ui/EventHistoryScreenTest.kt
+++ b/app/src/androidTest/java/com/github/studydistractor/sdp/ui/EventHistoryScreenTest.kt
@@ -63,6 +63,69 @@ class EventHistoryScreenTest {
         composeRule.onNodeWithTag("event-history-card__title NotFinishedEvent").assertDoesNotExist()
         composeRule.onNodeWithTag("event-history-card__title UserHasNotTakenPartIn").assertDoesNotExist()
     }
+
+    @Test
+    fun testChatButtonIsDisplayed(){
+        composeRule.onNodeWithTag("event-history-card__chat-button event1").assertExists()
+        composeRule.onNodeWithTag("event-history-card__chat-button event1").assertIsDisplayed()
+        composeRule.onNodeWithTag("event-history-card__chat-button event1").assertHasClickAction()
+        composeRule.onNodeWithTag("event-history-card__chat-button event1").assert(hasText("See Chat"))
+
+        composeRule.onNodeWithTag("event-history-card__chat-button event2").assertExists()
+        composeRule.onNodeWithTag("event-history-card__chat-button event2").assertIsDisplayed()
+        composeRule.onNodeWithTag("event-history-card__chat-button event2").assertHasClickAction()
+        composeRule.onNodeWithTag("event-history-card__chat-button event2").assert(hasText("See Chat"))
+
+        composeRule.onNodeWithTag("event-history-card__chat-button event3").assertExists()
+        composeRule.onNodeWithTag("event-history-card__chat-button event3").assertIsDisplayed()
+        composeRule.onNodeWithTag("event-history-card__chat-button event3").assertHasClickAction()
+        composeRule.onNodeWithTag("event-history-card__chat-button event3").assert(hasText("See Chat"))
+    }
+
+    @Test
+    fun testPointsButtonIsDisplayed(){
+        composeRule.onNodeWithTag("event-history-card__points-button event1").assertExists()
+        composeRule.onNodeWithTag("event-history-card__points-button event1").assertIsDisplayed()
+        composeRule.onNodeWithTag("event-history-card__points-button event1").assertHasClickAction()
+        composeRule.onNodeWithTag("event-history-card__points-button event1").assert(hasText("See Points"))
+
+        composeRule.onNodeWithTag("event-history-card__points-button event2").assertExists()
+        composeRule.onNodeWithTag("event-history-card__points-button event2").assertIsDisplayed()
+        composeRule.onNodeWithTag("event-history-card__points-button event2").assertHasClickAction()
+        composeRule.onNodeWithTag("event-history-card__points-button event2").assert(hasText("See Points"))
+
+        composeRule.onNodeWithTag("event-history-card__points-button event3").assertExists()
+        composeRule.onNodeWithTag("event-history-card__points-button event3").assertIsDisplayed()
+        composeRule.onNodeWithTag("event-history-card__points-button event3").assertHasClickAction()
+        composeRule.onNodeWithTag("event-history-card__points-button event3").assert(hasText("See Points"))
+    }
+
+    @Test
+    fun testChatButtonIsNotDisplayed(){
+        composeRule.onNodeWithTag("event-history-card__chat-button NotFinishedEvent").assertDoesNotExist()
+        composeRule.onNodeWithTag("event-history-card__chat-button UserHasNotTakenPartIn").assertDoesNotExist()
+    }
+
+    @Test
+    fun testEventHasName(){
+        composeRule.onNodeWithTag("event-history-card__title event1").assert(hasText("event1"))
+        composeRule.onNodeWithTag("event-history-card__title event2").assert(hasText("event2"))
+        composeRule.onNodeWithTag("event-history-card__title event3").assert(hasText("event3"))
+    }
+
+    @Test
+    fun testEventHasDate(){
+        composeRule.onNodeWithTag("event-history-card__date event1", true).assert(hasText("From 10-10-1997 00:00 to 11-11-1997 00:00"))
+        composeRule.onNodeWithTag("event-history-card__date event2", true).assert(hasText("From 10-10-1998 00:00 to 11-11-1998 00:00"))
+        composeRule.onNodeWithTag("event-history-card__date event3", true).assert(hasText("From 10-10-1999 00:00 to 11-11-1999 00:00"))
+    }
+
+    @Test
+    fun testEventHasDescription(){
+        composeRule.onNodeWithTag("event-history-card__description event1", true).assert(hasText("event1"))
+        composeRule.onNodeWithTag("event-history-card__description event2", true).assert(hasText("event2"))
+        composeRule.onNodeWithTag("event-history-card__description event3", true).assert(hasText("event3"))
+    }
 }
 
 class EventHistoryViewModelTest{
@@ -109,52 +172,4 @@ class EventHistoryViewModelTest{
         Assert.assertEquals(3,eventHistoryServiceFake.currentUser.score)
         Assert.assertEquals(old_size+ 1, eventHistoryServiceFake.eventClaimPoints.size)
     }
-
-
-
-    @Test
-    fun testChatButtonIsDisplayed(){
-        composeRule.onNodeWithTag("event-history-card__chat-button event1").assertExists()
-        composeRule.onNodeWithTag("event-history-card__chat-button event1").assertIsDisplayed()
-        composeRule.onNodeWithTag("event-history-card__chat-button event1").assertHasClickAction()
-        composeRule.onNodeWithTag("event-history-card__chat-button event1").assert(hasText("See Chat"))
-
-        composeRule.onNodeWithTag("event-history-card__chat-button event2").assertExists()
-        composeRule.onNodeWithTag("event-history-card__chat-button event2").assertIsDisplayed()
-        composeRule.onNodeWithTag("event-history-card__chat-button event2").assertHasClickAction()
-        composeRule.onNodeWithTag("event-history-card__chat-button event2").assert(hasText("See Chat"))
-
-        composeRule.onNodeWithTag("event-history-card__chat-button event3").assertExists()
-        composeRule.onNodeWithTag("event-history-card__chat-button event3").assertIsDisplayed()
-        composeRule.onNodeWithTag("event-history-card__chat-button event3").assertHasClickAction()
-        composeRule.onNodeWithTag("event-history-card__chat-button event3").assert(hasText("See Chat"))
-    }
-
-    @Test
-    fun testChatButtonIsNotDisplayed(){
-        composeRule.onNodeWithTag("event-history-card__chat-button NotFinishedEvent").assertDoesNotExist()
-        composeRule.onNodeWithTag("event-history-card__chat-button UserHasNotTakenPartIn").assertDoesNotExist()
-    }
-
-    @Test
-    fun testEventHasName(){
-        composeRule.onNodeWithTag("event-history-card__title event1").assert(hasText("event1"))
-        composeRule.onNodeWithTag("event-history-card__title event2").assert(hasText("event2"))
-        composeRule.onNodeWithTag("event-history-card__title event3").assert(hasText("event3"))
-    }
-
-    @Test
-    fun testEventHasDate(){
-        composeRule.onNodeWithTag("event-history-card__date event1", true).assert(hasText("From 10-10-1997 00:00 to 11-11-1997 00:00"))
-        composeRule.onNodeWithTag("event-history-card__date event2", true).assert(hasText("From 10-10-1998 00:00 to 11-11-1998 00:00"))
-        composeRule.onNodeWithTag("event-history-card__date event3", true).assert(hasText("From 10-10-1999 00:00 to 11-11-1999 00:00"))
-    }
-
-    @Test
-    fun testEventHasDescription(){
-        composeRule.onNodeWithTag("event-history-card__description event1", true).assert(hasText("event1"))
-        composeRule.onNodeWithTag("event-history-card__description event2", true).assert(hasText("event2"))
-        composeRule.onNodeWithTag("event-history-card__description event3", true).assert(hasText("event3"))
-    }
-
 }

--- a/app/src/main/java/com/github/studydistractor/sdp/createUser/CreateUserServiceFirebase.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/createUser/CreateUserServiceFirebase.kt
@@ -14,6 +14,7 @@ class CreateUserServiceFirebase : CreateUserModel {
 
     override fun createUser(user: UserData): Task<Void> {
         val uid = firebaseAuth.uid ?: return Tasks.forException(Exception("User is not in the db"))
+        user.id = uid
         return databaseRef.child(uid).setValue(user)
     }
 }

--- a/app/src/main/java/com/github/studydistractor/sdp/data/Event.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/data/Event.kt
@@ -15,7 +15,7 @@ package com.github.studydistractor.sdp.data
  * @property chatId id of the chat that is linked to the event
  */
 data class Event(
-    val eventId: String?,
+    val eventId: String,
     val name: String,
     val description: String,
     val lat: Double,
@@ -52,13 +52,13 @@ data class FirebaseEvent(
     val chatId: String? = null) {
     fun toEvent(): Event {
         return Event(
-            eventId, name!!, description!!, lat!!, long!!, start!!, end!!, lateParticipation, numberOfPoints!!, chatId!!
+            eventId!!, name!!, description!!, lat!!, long!!, start!!, end!!, lateParticipation, numberOfPoints!!, chatId!!
         )
     }
 }
 
 /**
- * represent participants of a particular events
+ * Represent participants of a particular events
  *
  * @property eventId id of the event
  * @property participants list of userId that participate in this event
@@ -71,8 +71,8 @@ data class EventParticipants(
 /**
  * Represent a chat that is received or sent from/to the firebase database
  *
- * @param chatId id of the chat
- * @param messageIds list of messageId that were sent in the chat
+ * @property eventId id of the chat
+ * @property participants list of messageId that were sent in the chat
  */
 data class FirebaseEventParticipants(
     val eventId: String? = null,
@@ -85,12 +85,27 @@ data class FirebaseEventParticipants(
     }
 }
 
+/**
+ * Represent the point to be claimed/claimed of a particular event
+ *
+ * @param eventId id of the chat
+ * @param claimUser list of users that have already claimed their points
+ */
 data class EventClaimPoints(
     val eventId: String = "",
     val claimUser: List<String> = listOf()
 )
 
+/**
+ * Represent the eventClaimPoint that is received or sent from/to the firebase database
+ */
 data class FirebaseEventClaimPoints(
     val eventId: String? = null,
     val claimUser: List<String>? = null
-)
+) {
+    fun toEventClaimPoints(): EventClaimPoints{
+        return EventClaimPoints(
+            eventId!!, claimUser!!
+        )
+    }
+}

--- a/app/src/main/java/com/github/studydistractor/sdp/data/Event.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/data/Event.kt
@@ -84,3 +84,13 @@ data class FirebaseEventParticipants(
         )
     }
 }
+
+data class EventClaimPoints(
+    val eventId: String = "",
+    val claimUser: List<String> = listOf()
+)
+
+data class FirebaseEventClaimPoints(
+    val eventId: String? = null,
+    val claimUser: List<String>? = null
+)

--- a/app/src/main/java/com/github/studydistractor/sdp/data/UserData.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/data/UserData.kt
@@ -11,12 +11,39 @@ package com.github.studydistractor.sdp.data
  * @constructor create a user
  */
 data class UserData(
+    var id: String = "",
+    var firstname: String = "",
+    var lastname: String = "",
+    var phone: String = "",
+    var birthday: Int = 0,
+    var score: Int= 0
+) {
+    fun updateScore(points: Int){
+        score += points
+    }
+}
+
+/**
+ * Represent a user that is received or sent from/to the firebase database
+ * @param id the id of the user
+ * @param firstname the firstname of the user
+ * @param lastname the lastname of the user
+ * @param phone the phone number of the user
+ * @param birthday a timestamp of the birthday of the user
+ * @param score the score of the user
+ */
+data class FirebaseUserData(
     var id: String? = null,
     var firstname: String? = null,
     var lastname: String? = null,
     var phone: String? = null,
     var birthday: Int? = null,
     var score: Int?= null
-)
+) {
+    fun toUserData(): UserData {
+        return UserData(id!!, firstname!!, lastname!!, phone!!, birthday!!, score!!)
+    }
+
+}
 
 

--- a/app/src/main/java/com/github/studydistractor/sdp/eventHistory/EventHistoryModel.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/eventHistory/EventHistoryModel.kt
@@ -1,7 +1,9 @@
 package com.github.studydistractor.sdp.eventHistory
 
 import com.github.studydistractor.sdp.data.Event
+import com.github.studydistractor.sdp.data.EventClaimPoints
 import com.github.studydistractor.sdp.data.EventParticipants
+import com.github.studydistractor.sdp.data.UserData
 import com.google.android.gms.tasks.Task
 
 interface EventHistoryModel {
@@ -18,9 +20,18 @@ interface EventHistoryModel {
      */
     fun observeEventsParticipants(onEventParticipantsChange: (List<EventParticipants>) -> Unit)
 
+    fun observeEventClaimPoints(onEventClaimPointsChange: (List<EventClaimPoints>) -> Unit)
+
+    fun observeCurrentUser(onCurrentUserChange: (UserData) -> Unit)
+
+    fun postUser(userData: UserData): Task<Void>
+
+    fun postEventClaimPoints(eventClaimPoints: EventClaimPoints): Task<Void>
+
     /**
      * Get the id of the current user
      * @return a task containing the id if successful
      */
     fun getCurrentUid() : Task<String>
+
 }

--- a/app/src/main/java/com/github/studydistractor/sdp/eventHistory/EventHistoryModel.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/eventHistory/EventHistoryModel.kt
@@ -20,18 +20,27 @@ interface EventHistoryModel {
      */
     fun observeEventsParticipants(onEventParticipantsChange: (List<EventParticipants>) -> Unit)
 
+    /**
+     * Observe the updates of the eventClaimPoints and call the given function on the values
+     * @param onEventClaimPointsChange the function to call
+     */
     fun observeEventClaimPoints(onEventClaimPointsChange: (List<EventClaimPoints>) -> Unit)
 
+    /**
+     * Observe the updates of the currentUser and call the given function on the values
+     * @param onCurrentUserChange the function to call
+     */
     fun observeCurrentUser(onCurrentUserChange: (UserData) -> Unit)
 
+    /**
+     * Upload a given user to the database
+     * @param userData the user to upload
+     */
     fun postUser(userData: UserData): Task<Void>
 
-    fun postEventClaimPoints(eventClaimPoints: EventClaimPoints): Task<Void>
-
     /**
-     * Get the id of the current user
-     * @return a task containing the id if successful
+     * Upload an event claim points to the database
+     * @param eventClaimPoints the event claim post to upload
      */
-    fun getCurrentUid() : Task<String>
-
+    fun postEventClaimPoints(eventClaimPoints: EventClaimPoints): Task<Void>
 }

--- a/app/src/main/java/com/github/studydistractor/sdp/eventHistory/EventHistoryServiceFirebase.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/eventHistory/EventHistoryServiceFirebase.kt
@@ -113,19 +113,14 @@ class EventHistoryServiceFirebase: EventHistoryModel {
                     } catch (e: Exception){
                         continue
                     }
-                    Log.d("AuthUid", auth.uid?: "Null id")
-                    Log.d("userid in listener", userData.id)
                     if (!auth.uid.isNullOrEmpty()
                         && userData.id == auth.uid
                     ){
                         onCurrentUserChange(userData)
-                        Log.d("userdata chosen", "userdata chosen")
                     }
 
                 }
             }
-
-            onEventParticipantsChange(eventsParticipants)
         }
 
         override fun onCancelled(error: DatabaseError) {

--- a/app/src/main/java/com/github/studydistractor/sdp/eventHistory/EventHistoryServiceFirebase.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/eventHistory/EventHistoryServiceFirebase.kt
@@ -163,16 +163,4 @@ class EventHistoryServiceFirebase: EventHistoryModel {
     override fun postEventClaimPoints(eventClaimPoints: EventClaimPoints): Task<Void> {
         return eventClaimPointsDatabaseRef.child(eventClaimPoints.eventId).setValue(eventClaimPoints)
     }
-
-
-    override fun getCurrentUid(): Task<String> {
-        val uid = auth.uid
-
-        if (uid.isNullOrEmpty()) {
-            Tasks.forException<Exception>(Exception("Empty or Null userId"))
-        }
-
-        return Tasks.forResult(uid)
-    }
-
 }

--- a/app/src/main/java/com/github/studydistractor/sdp/eventHistory/EventHistoryServiceFirebase.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/eventHistory/EventHistoryServiceFirebase.kt
@@ -10,7 +10,6 @@ import com.github.studydistractor.sdp.data.FirebaseEventParticipants
 import com.github.studydistractor.sdp.data.FirebaseUserData
 import com.github.studydistractor.sdp.data.UserData
 import com.google.android.gms.tasks.Task
-import com.google.android.gms.tasks.Tasks
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.database.DataSnapshot
 import com.google.firebase.database.DatabaseError
@@ -51,7 +50,6 @@ class EventHistoryServiceFirebase: EventHistoryModel {
                     }
                 }
             }
-            Log.d("Event", "${events.size}")
             onEventChange(events)
         }
 
@@ -63,17 +61,16 @@ class EventHistoryServiceFirebase: EventHistoryModel {
         override fun onDataChange(snapshot: DataSnapshot) {
             val eventsParticipants = mutableListOf<EventParticipants>()
             for (children in snapshot.children) {
-                val fep = children.getValue(FirebaseEventParticipants::class.java)
-                if (fep != null) {
+                val firebaseEventParticipants = children.getValue(FirebaseEventParticipants::class.java)
+                if (firebaseEventParticipants != null) {
                     try {
-                        val ep = fep.toEventParticipants()
-                        eventsParticipants.add(ep)
+                        val eventParticipants = firebaseEventParticipants.toEventParticipants()
+                        eventsParticipants.add(eventParticipants)
                     } catch(e: Exception){
                         continue
                     }
                 }
             }
-            Log.d("EventParticipants", "${eventsParticipants.size}")
             onEventParticipantsChange(eventsParticipants)
         }
 
@@ -85,11 +82,11 @@ class EventHistoryServiceFirebase: EventHistoryModel {
         override fun onDataChange(snapshot: DataSnapshot) {
             val eventClaimPoints = mutableListOf<EventClaimPoints>()
             for (children in snapshot.children) {
-                val fcp = children.getValue(FirebaseEventClaimPoints::class.java)
-                if (fcp != null) {
+                val firebaseEventClaimPoints = children.getValue(FirebaseEventClaimPoints::class.java)
+                if (firebaseEventClaimPoints != null) {
                     try {
-                        val cp = fcp.toEventClaimPoints()
-                        eventClaimPoints.add(cp)
+                        val claimPoints = firebaseEventClaimPoints.toEventClaimPoints()
+                        eventClaimPoints.add(claimPoints)
                     } catch(e: Exception){
                         continue
                     }

--- a/app/src/main/java/com/github/studydistractor/sdp/eventHistory/EventHistoryServiceFirebase.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/eventHistory/EventHistoryServiceFirebase.kt
@@ -1,54 +1,57 @@
 package com.github.studydistractor.sdp.eventHistory
 
 import android.util.Log
-import androidx.compose.runtime.mutableStateListOf
 import com.github.studydistractor.sdp.data.Event
+import com.github.studydistractor.sdp.data.EventClaimPoints
 import com.github.studydistractor.sdp.data.EventParticipants
 import com.github.studydistractor.sdp.data.FirebaseEvent
+import com.github.studydistractor.sdp.data.FirebaseEventClaimPoints
 import com.github.studydistractor.sdp.data.FirebaseEventParticipants
+import com.github.studydistractor.sdp.data.FirebaseUserData
+import com.github.studydistractor.sdp.data.UserData
 import com.google.android.gms.tasks.Task
 import com.google.android.gms.tasks.Tasks
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.database.DataSnapshot
 import com.google.firebase.database.DatabaseError
-import com.google.firebase.database.DatabaseReference
 import com.google.firebase.database.FirebaseDatabase
 import com.google.firebase.database.ValueEventListener
 
 class EventHistoryServiceFirebase: EventHistoryModel {
+    private val db = FirebaseDatabase.getInstance()
+
     private val eventPaths = "Events"
-    private val eventDatabaseRef: DatabaseReference =
-        FirebaseDatabase.getInstance().getReference(eventPaths)
     private val eventParticipantsPaths = "EventParticipants"
-    private val eventParticipantsDatabaseRef: DatabaseReference =
-        FirebaseDatabase.getInstance().getReference(eventParticipantsPaths)
+    private val eventClaimPointsPath = "EventClaimPoints"
+    private val usersPath = "Users"
+
+    private val eventDatabaseRef = db.getReference(eventPaths)
+    private val eventParticipantsDatabaseRef = db.getReference(eventParticipantsPaths)
+    private val eventClaimPointsDatabaseRef = db.getReference(eventClaimPointsPath)
+    private val usersDatabaseRef = db.getReference(usersPath)
+
     private var auth: FirebaseAuth = FirebaseAuth.getInstance()
 
     private var onEventChange: (List<Event>) -> Unit = {}
     private var onEventParticipantsChange: (List<EventParticipants>) -> Unit = {}
+    private var onEventClaimPointsChange: (List<EventClaimPoints>) -> Unit = {}
+    private var onCurrentUserChange: (UserData) -> Unit = {}
 
     private val eventListener = object : ValueEventListener {
         override fun onDataChange(snapshot: DataSnapshot) {
-            val firebaseEvents = mutableStateListOf<FirebaseEvent>()
-            for (event in snapshot.children) {
-                val eventItem = event.getValue(FirebaseEvent::class.java)
-                if (eventItem != null) {
-                    firebaseEvents.add(eventItem)
-                }
-            }
-
             val events = mutableListOf<Event>()
-
-            for (fe in firebaseEvents) {
-                val ev: Event
-                try {
-                    ev = fe.toEvent()
-                } catch (e: Exception) {
-                    continue
+            for (children in snapshot.children) {
+                val firebaseEvent = children.getValue(FirebaseEvent::class.java)
+                if (firebaseEvent != null) {
+                    try {
+                        val event = firebaseEvent.toEvent()
+                        events.add(event)
+                    } catch (e: Exception) {
+                        continue
+                    }
                 }
-
-                events.add(ev)
             }
+            Log.d("Event", "${events.size}")
             onEventChange(events)
         }
 
@@ -56,29 +59,21 @@ class EventHistoryServiceFirebase: EventHistoryModel {
             Log.d("Firebase Event", "loadPost:onCancelled " + error.toException().toString())
         }
     }
-
     private val eventParticipantsListener = object : ValueEventListener {
         override fun onDataChange(snapshot: DataSnapshot) {
-            val firebaseEventParticipants = mutableStateListOf<FirebaseEventParticipants>()
-            for (eP in snapshot.children) {
-                val eventParticipantsItem = eP.getValue(FirebaseEventParticipants::class.java)
-                if (eventParticipantsItem != null) {
-                    firebaseEventParticipants.add(eventParticipantsItem)
-                }
-            }
-
             val eventsParticipants = mutableListOf<EventParticipants>()
-            for (fep in firebaseEventParticipants){
-                val ep : EventParticipants
-                try {
-                    ep = fep.toEventParticipants()
-                } catch(e: Exception){
-                    continue
+            for (children in snapshot.children) {
+                val fep = children.getValue(FirebaseEventParticipants::class.java)
+                if (fep != null) {
+                    try {
+                        val ep = fep.toEventParticipants()
+                        eventsParticipants.add(ep)
+                    } catch(e: Exception){
+                        continue
+                    }
                 }
-
-                eventsParticipants.add(ep)
             }
-
+            Log.d("EventParticipants", "${eventsParticipants.size}")
             onEventParticipantsChange(eventsParticipants)
         }
 
@@ -86,10 +81,63 @@ class EventHistoryServiceFirebase: EventHistoryModel {
             Log.d("Firebase Event Participant", "loadPost:onCancelled " + error.toException().toString())
         }
     }
+    private val eventClaimPointsListener = object : ValueEventListener {
+        override fun onDataChange(snapshot: DataSnapshot) {
+            val eventClaimPoints = mutableListOf<EventClaimPoints>()
+            for (children in snapshot.children) {
+                val fcp = children.getValue(FirebaseEventClaimPoints::class.java)
+                if (fcp != null) {
+                    try {
+                        val cp = fcp.toEventClaimPoints()
+                        eventClaimPoints.add(cp)
+                    } catch(e: Exception){
+                        continue
+                    }
+                }
+            }
+            onEventClaimPointsChange(eventClaimPoints)
+        }
+
+        override fun onCancelled(error: DatabaseError) {
+            Log.d("Firebase Event Claim Points", "loadPost:onCancelled " + error.toException().toString())
+        }
+    }
+    private val userListener = object : ValueEventListener {
+        override fun onDataChange(snapshot: DataSnapshot) {
+            for (children in snapshot.children){
+                val firebaseUserData = children.getValue(FirebaseUserData::class.java)
+                if (firebaseUserData != null){
+                    val userData : UserData
+                    try {
+                        userData = firebaseUserData.toUserData()
+                    } catch (e: Exception){
+                        continue
+                    }
+                    Log.d("AuthUid", auth.uid?: "Null id")
+                    Log.d("userid in listener", userData.id)
+                    if (!auth.uid.isNullOrEmpty()
+                        && userData.id == auth.uid
+                    ){
+                        onCurrentUserChange(userData)
+                        Log.d("userdata chosen", "userdata chosen")
+                    }
+
+                }
+            }
+
+            onEventParticipantsChange(eventsParticipants)
+        }
+
+        override fun onCancelled(error: DatabaseError) {
+            Log.d("Firebase User", "loadPost:onCancelled " + error.toException().toString())
+        }
+    }
 
     init {
         eventDatabaseRef.addValueEventListener(eventListener)
         eventParticipantsDatabaseRef.addValueEventListener(eventParticipantsListener)
+        eventClaimPointsDatabaseRef.addValueEventListener(eventClaimPointsListener)
+        usersDatabaseRef.addValueEventListener(userListener)
     }
 
     override fun observeEvents(onEventChange: (List<Event>) -> Unit){
@@ -99,6 +147,23 @@ class EventHistoryServiceFirebase: EventHistoryModel {
     override fun observeEventsParticipants(onEventParticipantsChange: (List<EventParticipants>) -> Unit){
         this.onEventParticipantsChange = onEventParticipantsChange
     }
+
+    override fun observeEventClaimPoints(onEventClaimPointsChange: (List<EventClaimPoints>) -> Unit) {
+        this.onEventClaimPointsChange = onEventClaimPointsChange
+    }
+
+    override fun observeCurrentUser(onCurrentUserChange: (UserData) -> Unit) {
+        this.onCurrentUserChange = onCurrentUserChange
+    }
+
+    override fun postUser(userData: UserData): Task<Void>{
+        return usersDatabaseRef.child(userData.id).setValue(userData)
+    }
+
+    override fun postEventClaimPoints(eventClaimPoints: EventClaimPoints): Task<Void> {
+        return eventClaimPointsDatabaseRef.child(eventClaimPoints.eventId).setValue(eventClaimPoints)
+    }
+
 
     override fun getCurrentUid(): Task<String> {
         val uid = auth.uid

--- a/app/src/main/java/com/github/studydistractor/sdp/eventHistory/EventHistoryViewModel.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/eventHistory/EventHistoryViewModel.kt
@@ -1,11 +1,16 @@
 package com.github.studydistractor.sdp.eventHistory
 
+import android.util.Log
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.lifecycle.ViewModel
 import com.github.studydistractor.sdp.data.Event
+import com.github.studydistractor.sdp.data.EventClaimPoints
 import com.github.studydistractor.sdp.data.EventParticipants
+import com.github.studydistractor.sdp.data.UserData
 import com.github.studydistractor.sdp.ui.state.EventHistoryUiState
+import com.google.android.gms.tasks.Task
+import com.google.android.gms.tasks.Tasks
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -22,6 +27,8 @@ class EventHistoryViewModel(
     private val _eventHistoryModel = eventHistoryModel
     private var events : List<Event> = listOf()
     private var eventParticipants: List<EventParticipants> = listOf()
+    private var eventsClaimPoints: List<EventClaimPoints> = listOf()
+    private var currentUser : UserData = UserData()
 
     val uiState: StateFlow<EventHistoryUiState> = _uiState.asStateFlow()
 
@@ -32,6 +39,15 @@ class EventHistoryViewModel(
         }
         _eventHistoryModel.observeEventsParticipants {
             t -> eventParticipants = t
+            refreshEventHistory()
+        }
+        _eventHistoryModel.observeEventClaimPoints {
+            t -> eventsClaimPoints = t
+            refreshEventHistory()
+        }
+
+        _eventHistoryModel.observeCurrentUser {
+            t -> currentUser = t
             refreshEventHistory()
         }
 
@@ -50,13 +66,12 @@ class EventHistoryViewModel(
         return endDate.before(date)
     }
 
-    fun refreshEventHistory(){
-        val uid = _eventHistoryModel.getCurrentUid().result
+    private fun refreshEventHistory(){
         val usersEvent : SnapshotStateList<Event> = mutableStateListOf()
 
         for (eP in eventParticipants){
             if (eP.participants == null) continue
-            if (eP.participants.contains(uid)){
+            if (eP.participants.contains(currentUser.id)){
                 for (ev in events){
                     if (ev.eventId == eP.eventId && eventIsFinished(ev)){
                         usersEvent.add(ev)
@@ -67,5 +82,51 @@ class EventHistoryViewModel(
 
         _uiState.update { EventHistoryUiState(usersEvent) }
     }
+
+    fun claimPoints(eventId: String): Task<Void> {
+        if (eventId.isEmpty()) return Tasks.forException(Exception("Empty eventId"))
+        for (cp in eventsClaimPoints){
+            if (cp.eventId == eventId){
+                if (cp.claimUser.contains(currentUser.id)){
+                    return Tasks.forException(Exception("Points already claimed"))
+                }
+
+                val event = getEvent(eventId) ?: return Tasks.forException(Exception("Null event"))
+
+                val newClaimUser = mutableStateListOf<String>()
+                newClaimUser.addAll(cp.claimUser)
+                newClaimUser.add(currentUser.id)
+
+                val newClaimPoints = EventClaimPoints(cp.eventId, newClaimUser)
+
+                val newUser = currentUser.copy()
+                newUser.updateScore(event.numberOfPoints)
+
+                return _eventHistoryModel
+                    .postUser(newUser) .continueWithTask{
+                        _eventHistoryModel.postEventClaimPoints(newClaimPoints)}
+            }
+        }
+
+        val event = getEvent(eventId) ?: return Tasks.forException(Exception("Null event"))
+
+        val newClaimPoints = EventClaimPoints(eventId, listOf(currentUser.id))
+
+        val newUser = currentUser.copy()
+        newUser.updateScore(event.numberOfPoints)
+
+
+        return _eventHistoryModel
+            .postUser(newUser) .continueWithTask{
+                _eventHistoryModel.postEventClaimPoints(newClaimPoints)}
+    }
+
+    private fun getEvent(eventId: String): Event? {
+        for (ev in events){
+            if (ev.eventId == eventId) return ev
+        }
+        return null
+    }
+
 
 }

--- a/app/src/main/java/com/github/studydistractor/sdp/ui/EventHistoryScreen.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/ui/EventHistoryScreen.kt
@@ -48,7 +48,12 @@ fun EventHistoryScreen(
         )
         LazyColumn(){
             items(uiState.eventHistory) {i->
-                EventHistoryCard(i, chatViewModel, onChatButtonClicked)
+                EventHistoryCard(
+                    i,
+                    chatViewModel,
+                    onChatButtonClicked,
+                    eventHistoryViewModel
+                )
             }
         }
     }

--- a/app/src/main/java/com/github/studydistractor/sdp/ui/components/EventHistoryCard.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/ui/components/EventHistoryCard.kt
@@ -1,5 +1,7 @@
 package com.github.studydistractor.sdp.ui.components
 
+import android.content.Context
+import android.widget.Toast
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -9,6 +11,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.CutCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.Button
@@ -20,10 +23,14 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.github.studydistractor.sdp.data.Event
+import com.github.studydistractor.sdp.data.EventClaimPoints
 import com.github.studydistractor.sdp.eventChat.EventChatViewModel
+import com.github.studydistractor.sdp.eventHistory.EventHistoryViewModel
+import com.google.android.gms.tasks.Task
 
 /**
  * The function representing an event in the history of events
@@ -32,12 +39,14 @@ import com.github.studydistractor.sdp.eventChat.EventChatViewModel
 fun EventHistoryCard(
     event: Event,
     chatViewModel: EventChatViewModel,
-    onChatClicked: () -> Unit
+    onChatClicked: () -> Unit,
+    eventHistoryViewModel: EventHistoryViewModel
 ){
 
     Row(modifier = Modifier.padding(all = 8.dp)
     ) {
         var isExpanded by remember { mutableStateOf(false) }
+        val context = LocalContext.current
 
         Column(
             modifier = Modifier
@@ -79,33 +88,42 @@ fun EventHistoryCard(
                 )
             }
 
-            Button(
-                onClick = {
-                    chatViewModel.changeEventChat(event.eventId!!)
-                    onChatClicked()
-                },
-                modifier = Modifier
-                    .padding(top = 8.dp)
-                    .testTag("event-history-card__chat-button " + event.eventId),
-            ) {
-                Text(
-                    "See Chat",
+            Row() {
+                Button(
+                    onClick = {
+                        chatViewModel.changeEventChat(event.eventId!!)
+                        onChatClicked()
+                    },
                     modifier = Modifier
-                        .testTag("event-history-card__chat-button-text " + event.eventId),
-                )
+                        .padding(top = 8.dp)
+                        .testTag("event-history-card__chat-button " + event.eventId),
+                ) {
+                    Text(
+                        "See Chat",
+                        modifier = Modifier
+                            .testTag("event-history-card__chat-button-text " + event.eventId),
+                    )
+                }
+                Button(
+                    onClick = {
+                        eventHistoryViewModel.claimPoints(event.eventId)
+                            .addOnSuccessListener {
+                                Toast.makeText(context, "Points added", Toast.LENGTH_SHORT)
+                                    .show()
+                            }
+                            .addOnFailureListener {
+                                Toast.makeText(context, "${it.message}", Toast.LENGTH_SHORT)
+                                    .show()
+                            }
+                    },
+                    modifier = Modifier.padding(all = 4.dp),
+                    shape = CutCornerShape(1)
+                ) {
+                    Text(
+                        "Claim Points"
+                    )
+                }
             }
-
-            Button(
-                onClick = {
-
-                },
-            ) {
-                Text(
-                    "Claim Points"
-                )
-            }
-
-
         }
     }
 

--- a/app/src/main/java/com/github/studydistractor/sdp/ui/components/EventHistoryCard.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/ui/components/EventHistoryCard.kt
@@ -95,7 +95,7 @@ fun EventHistoryCard(
                         onChatClicked()
                     },
                     modifier = Modifier
-                        .padding(top = 8.dp)
+                        .padding(4.dp)
                         .testTag("event-history-card__chat-button " + event.eventId),
                 ) {
                     Text(
@@ -116,8 +116,9 @@ fun EventHistoryCard(
                                     .show()
                             }
                     },
-                    modifier = Modifier.padding(all = 4.dp),
-                    shape = CutCornerShape(1)
+                    modifier = Modifier
+                        .padding(4.dp)
+                        .testTag("event-history-card__points-button " + event.eventId),
                 ) {
                     Text(
                         "Claim Points"

--- a/app/src/main/java/com/github/studydistractor/sdp/ui/components/EventHistoryCard.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/ui/components/EventHistoryCard.kt
@@ -94,6 +94,18 @@ fun EventHistoryCard(
                         .testTag("event-history-card__chat-button-text " + event.eventId),
                 )
             }
+
+            Button(
+                onClick = {
+
+                },
+            ) {
+                Text(
+                    "Claim Points"
+                )
+            }
+
+
         }
     }
 


### PR DESCRIPTION
In this PR, the button to claim the points of an event in the event history has been implemented. To do it, the `EventClaimPoints` data class (and its firebase equivalent `FirebaseEventClaimPoints`) has been created to store which users have already claimed their points. On another note, the `UserData` class has been adapted to have its firebase equivalent `FirebaseUserData`. Of course, all the classes that uses the `UserData` data class have been modified and adapted. Closes #145 

<img width="310" alt="Capture d’écran 2023-05-18 à 10 52 25" src="https://github.com/StudyDistractor/sdp/assets/100271931/cd7fc4a4-d4f8-483d-adc4-d727b0584aa5">

Here's the UI once merged