### PR TITLE
feat: completing a distraction is now added to history

### DIFF
--- a/app/src/main/java/com/github/studydistractor/sdp/distraction/DistractionViewModel.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/distraction/DistractionViewModel.kt
@@ -43,10 +43,16 @@ class DistractionViewModel(
         }
     }
 
+    /**
+     * Return true if the given distraction is bookmarked by the user else false
+     */
     fun isBookmarked(distraction: Distraction): Boolean {
         return bookmarksService.isBookmarked(distraction)
     }
 
+    /**
+     * Act as a toggle for bookmark and handle bookmarked value
+     */
     fun handleBookmark(): Task<Void> {
         return if(isBookmarked(_uiState.value.distraction)) {
             bookmarked = false
@@ -57,6 +63,9 @@ class DistractionViewModel(
         }
     }
 
+    /**
+     * Update the UI each time the bookmark value is changed
+     */
     fun onChangedBookmark() {
         if(bookmarked) {
             Log.d("boomarked", "update UI to true")
@@ -67,10 +76,18 @@ class DistractionViewModel(
         }
     }
 
+    /**
+     * helper function that inverts the value of bookmarked
+     */
     fun reverseBookmarked() {
         bookmarked = !bookmarked
     }
 
+    /**
+     * Add the current displayed distraction to the user's history
+     *
+     * return false in case the user is not logged in
+     */
     fun distractionCompleted(): Boolean {
         val distraction = _uiState.value.distraction
         return historyService.addHistoryEntry(
@@ -83,6 +100,9 @@ class DistractionViewModel(
         )
     }
 
+    /**
+     * Helper function to get the current time in a `Long` format
+     */
     private fun currentTimeToLong(): Long {
         return System.currentTimeMillis()
     }

--- a/app/src/main/java/com/github/studydistractor/sdp/distraction/DistractionViewModel.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/distraction/DistractionViewModel.kt
@@ -5,6 +5,9 @@ import androidx.lifecycle.ViewModel
 import com.github.studydistractor.sdp.bookmark.BookmarkModel
 import com.github.studydistractor.sdp.bookmark.BookmarkServiceFirebase
 import com.github.studydistractor.sdp.data.Distraction
+import com.github.studydistractor.sdp.data.HistoryEntry
+import com.github.studydistractor.sdp.history.HistoryModel
+import com.github.studydistractor.sdp.history.HistoryServiceFirebase
 import com.github.studydistractor.sdp.ui.state.DistractionUiState
 import com.google.android.gms.tasks.Task
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -16,7 +19,8 @@ import kotlinx.coroutines.flow.update
  * This class help passing distraction data between views
  */
 class DistractionViewModel(
-    private val bookmarksService : BookmarkModel = BookmarkServiceFirebase()
+    private val bookmarksService : BookmarkModel = BookmarkServiceFirebase(),
+    private val historyService: HistoryModel = HistoryServiceFirebase()
 ) : ViewModel(){
 
     private val _uiState = MutableStateFlow(DistractionUiState())
@@ -65,5 +69,21 @@ class DistractionViewModel(
 
     fun reverseBookmarked() {
         bookmarked = !bookmarked
+    }
+
+    fun distractionCompleted(): Boolean {
+        val distraction = _uiState.value.distraction
+        return historyService.addHistoryEntry(
+            entry = HistoryEntry(
+                name = distraction.name!!,
+                description = distraction.description!!,
+                date = currentTimeToLong()
+            ),
+            uid = historyService.getCurrentUid()!!
+        )
+    }
+
+    private fun currentTimeToLong(): Long {
+        return System.currentTimeMillis()
     }
 }

--- a/app/src/main/java/com/github/studydistractor/sdp/history/HistoryViewModel.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/history/HistoryViewModel.kt
@@ -18,7 +18,9 @@ class HistoryViewModel(
         if(_historyModel.getCurrentUid() == null) return
         val uid = _historyModel.getCurrentUid()!!
         _uiState.update {
-            HistoryUiState(_historyModel.getHistory(uid))
+            it.copy(
+                historyEntries = _historyModel.getHistory(uid)
+            )
         }
     }
 

--- a/app/src/main/java/com/github/studydistractor/sdp/ui/DistractionScreen.kt
+++ b/app/src/main/java/com/github/studydistractor/sdp/ui/DistractionScreen.kt
@@ -131,11 +131,13 @@ fun DistractionScreen(
                 }
                 Spacer(modifier = Modifier.padding(8.dp))
                 Button(onClick = {
-                    Toast.makeText(
-                        context,
-                        "Activity completed!",
-                        Toast.LENGTH_SHORT
-                    ).show()
+                    if(distractionViewModel.distractionCompleted()) {
+                        Toast.makeText(
+                            context,
+                            "Activity completed!",
+                            Toast.LENGTH_SHORT
+                        ).show()
+                    }
                 }, modifier = Modifier.testTag("completeButton")) {
                     Text(text = "Activity completed!", color = Color.White)
 


### PR DESCRIPTION
The history screen was broken and no linking was made when you clicked on the 'Activity completed' button in the distraction screen. It is now working.